### PR TITLE
Use go_router package for navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ The dependency injector first spins up the network communication modules by runn
 are initiated afterwards. Lastly, the `BlocInjector` is run at last, as the `blocs` are the top-layer
 components, built on the other components.
 
+### Navigation
+
+The [go_router](https://pub.dev/packages/go_router) package is used for navigation. The navigation
+needs to support navigation patterns on Android, iOS and Web. Due to the later, `go_router` is a
+perfect candidate for navigation.
+
+The navigation routes are encapsulated in the enum `DanteRoute` class. The main reason for doing 
+this, is that all routes are defined in one place. The risk of using wrong routes with 
+corresponding 404 errors are mitigated.
+
 ### Developer Setup
 
 Android Studio is the recommended IDE for every OS, although it is not mandatory to use it.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -100,6 +100,7 @@ enum DanteRoute {
     navigationUrl: '/profile',
   );
 
+  /// Url used for registering the route in the [_router] field.
   final String url;
   /// Used for navigating to another screen, when calling context.go()
   final String navigationUrl;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,15 +2,18 @@ import 'dart:async';
 
 import 'package:dantex/firebase_options.dart';
 import 'package:dantex/src/providers/authentication.dart';
-import 'package:dantex/src/providers/bloc.dart';
+import 'package:dantex/src/ui/boot_page.dart';
 import 'package:dantex/src/ui/login/login_page.dart';
 import 'package:dantex/src/ui/main/main_page.dart';
+import 'package:dantex/src/ui/profile/profile_page.dart';
+import 'package:dantex/src/ui/settings/settings_page.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 void main() async {
@@ -21,6 +24,11 @@ void main() async {
       final firebaseApp = await Firebase.initializeApp(
         options: DefaultFirebaseOptions.currentPlatform,
       );
+
+      // Don't record errors with Crashlytics on Web
+      if (!kIsWeb) {
+        FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+      }
 
       runApp(
         ProviderScope(
@@ -46,7 +54,8 @@ class DanteXApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return MaterialApp(
+    return MaterialApp.router(
+      routerConfig: _router,
       title: 'Dante',
       debugShowCheckedModeBanner: false,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -64,26 +73,67 @@ class DanteXApp extends ConsumerWidget {
         textTheme: GoogleFonts.nunitoTextTheme(),
         useMaterial3: true,
       ),
-      home: FutureBuilder<bool>(
-        future: _launcher(ref),
-        builder: (context, snapshot) {
-          if (snapshot.hasData) {
-            return snapshot.data! ? const MainPage() : const LoginPage();
-          } else {
-            return const Material(child: CircularProgressIndicator.adaptive());
-          }
-        },
-      ),
     );
   }
 
-  Future<bool> _launcher(WidgetRef ref) async {
-    // Don't record errors with Crashlytics on Web
-    if (!kIsWeb) {
-      FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
-    }
-
-    final bloc = ref.read(authBlocProvider);
-    return bloc.isLoggedIn();
-  }
 }
+
+enum DanteRoute {
+  boot(
+    url: '/boot',
+    navigationUrl: '/boot',
+  ),
+  login(
+    url: '/login',
+    navigationUrl: '/login',
+  ),
+  dashboard(
+    url: '/',
+    navigationUrl: '/',
+  ),
+  settings(
+    url: 'settings',
+    navigationUrl: '/settings',
+  ),
+  profile(
+    url: 'profile',
+    navigationUrl: '/profile',
+  );
+
+  final String url;
+  /// Used for navigating to another screen, when calling context.go()
+  final String navigationUrl;
+
+  const DanteRoute({
+    required this.url,
+    required this.navigationUrl,
+  });
+}
+
+final GoRouter _router = GoRouter(
+  initialLocation: DanteRoute.boot.url,
+  routes: [
+    GoRoute(
+      path: DanteRoute.boot.url,
+      builder: (BuildContext context, GoRouterState state) => const BootPage(),
+    ),
+    GoRoute(
+      path: DanteRoute.login.url,
+      builder: (BuildContext context, GoRouterState state) => const LoginPage(),
+    ),
+    GoRoute(
+      path: DanteRoute.dashboard.url,
+      builder: (BuildContext context, GoRouterState state) => const MainPage(),
+      routes: [
+        GoRoute(
+          path: DanteRoute.settings.url,
+          builder: (BuildContext context, GoRouterState state) => const SettingsPage(),
+        ),
+        GoRoute(
+          path: DanteRoute.profile.url,
+          builder: (BuildContext context, GoRouterState state) => const ProfilePage(),
+        ),
+      ],
+    ),
+  ],
+);

--- a/lib/src/ui/boot_page.dart
+++ b/lib/src/ui/boot_page.dart
@@ -1,0 +1,50 @@
+import 'package:dantex/main.dart';
+import 'package:dantex/src/bloc/auth/auth_bloc.dart';
+import 'package:dantex/src/providers/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class BootPage extends ConsumerStatefulWidget {
+  const BootPage({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _BootPageState();
+}
+
+class _BootPageState extends ConsumerState<BootPage> {
+  AuthBloc get _bloc => ref.read(authBlocProvider);
+
+  @override
+  void initState() {
+    _bloc.isLoggedIn().then(
+      (isLoggedIn) {
+        String navigationUrl = isLoggedIn ? DanteRoute.dashboard.navigationUrl : DanteRoute.login.navigationUrl;
+        context.pushReplacement(navigationUrl);
+      },
+    );
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Image.asset(
+            'assets/logo/ic-launcher.jpg',
+            width: 96,
+            height: 96,
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: MediaQuery.of(context).size.width * 0.4,
+            child: const LinearProgressIndicator(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/ui/core/dante_app_bar.dart
+++ b/lib/src/ui/core/dante_app_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dantex/main.dart';
 import 'package:dantex/src/bloc/auth/auth_bloc.dart';
 import 'package:dantex/src/bloc/auth/logout_event.dart';
 import 'package:dantex/src/data/authentication/entity/dante_user.dart';
@@ -8,12 +9,10 @@ import 'package:dantex/src/ui/add/add_book_sheet.dart';
 import 'package:dantex/src/ui/core/dante_components.dart';
 import 'package:dantex/src/ui/core/dante_search_bar.dart';
 import 'package:dantex/src/ui/core/platform_components.dart';
-import 'package:dantex/src/ui/login/login_page.dart';
-import 'package:dantex/src/ui/profile/profile_page.dart';
-import 'package:dantex/src/ui/settings/settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 enum AddBookAction { scan, query, manual }
 
@@ -57,13 +56,7 @@ class DanteAppBarState extends ConsumerState<DanteAppBar> {
 
   void _logoutEventReceived(LogoutEvent event) {
     if (event == LogoutEvent.logout) {
-      // Navigate to login and remove everything from navigation stack.
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(
-          builder: (context) => const LoginPage(),
-        ),
-        (route) => false,
-      );
+      context.pushReplacement(DanteRoute.login.navigationUrl);
     }
   }
 
@@ -231,13 +224,7 @@ class DanteAppBarState extends ConsumerState<DanteAppBar> {
                   _MenuItem(
                     text: 'Settings',
                     icon: Icons.settings_outlined,
-                    onItemClicked: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (context) => const SettingsPage(),
-                        ),
-                      );
-                    },
+                    onItemClicked: () => context.go(DanteRoute.settings.navigationUrl),
                   ),
                 ],
               ),
@@ -253,13 +240,7 @@ class DanteAppBarState extends ConsumerState<DanteAppBar> {
     return Row(
       children: [
         IconButton(
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const ProfilePage(),
-              ),
-            );
-          },
+          onPressed: () => context.go(DanteRoute.profile.navigationUrl),
           icon: _getUserAvatar(),
         ),
         const SizedBox(width: 4),

--- a/lib/src/ui/login/login_page.dart
+++ b/lib/src/ui/login/login_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:dantex/main.dart';
 import 'package:dantex/src/bloc/auth/auth_bloc.dart';
 import 'package:dantex/src/bloc/auth/login_event.dart';
 import 'package:dantex/src/bloc/auth/management_event.dart';
@@ -8,10 +9,10 @@ import 'package:dantex/src/providers/bloc.dart';
 import 'package:dantex/src/ui/core/dante_components.dart';
 import 'package:dantex/src/ui/core/platform_components.dart';
 import 'package:dantex/src/ui/login/email_bottom_sheet.dart';
-import 'package:dantex/src/ui/main/main_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -81,9 +82,8 @@ class LoginPageState extends ConsumerState<LoginPage> {
       setState(() {
         _isLoading = false;
       });
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => const MainPage()),
-      );
+
+      context.pushReplacement(DanteRoute.dashboard.navigationUrl);
     }
   }
 
@@ -97,8 +97,8 @@ class LoginPageState extends ConsumerState<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      child: Container(
+    return Scaffold(
+      body: Container(
         decoration: BoxDecoration(color: Theme.of(context).colorScheme.surfaceVariant),
         child: Center(
           child: _isLoading

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -581,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: a07c781bf55bf11ae85133338e4850f0b4e33e261c44a66c750fc707d65d8393
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.2"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   flutter_riverpod: ^2.4.0
   riverpod_annotation: ^2.1.5
   collection: ^1.17.2
+  go_router: ^11.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Overview

Use the `go_router` package for navigation. 

The navigation routes are encapsulated in the enum `DanteRoute` class. The main reason for doing  this, is that all routes are defined in one place. The risk of using wrong routes with corresponding 404 errors are mitigated.

We can only navigate to routes that are defined in this enum.