### PR TITLE
Fix route for scan books

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,8 +93,8 @@ enum DanteRoute {
     navigationUrl: '/',
   ),
   scanBook(
-    url: '/scan',
-    navigationUrl: '/scan'
+    url: 'scan',
+    navigationUrl: '/scan',
   ),
   settings(
     url: 'settings',


### PR DESCRIPTION
The leading slash in `url` makes the app crash on startup. Removing the slash fixed the crash.