### PR TITLE
21: add statistics screen

### DIFF
--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -111,6 +111,15 @@
       "fastest-book": "Schnellstes Buch",
       "slowest-book": "Langsamstes Buch",
       "days": "{} Tage"
+    },
+    "misc": {
+      "title": "Verschiedenes",
+      "average-books": {
+        "description": "Bücher pro Monat"
+      },
+      "most-read-month": {
+        "description": "Bücher im {}"
+      }
     }
   },
   "no_thanks": "Nein danke",

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -114,12 +114,27 @@
     },
     "misc": {
       "title": "Verschiedenes",
+      "empty": "Keine Daten verfügbar.",
       "average-books": {
         "description": "Bücher pro Monat"
       },
       "most-read-month": {
         "description": "Bücher im {}"
       }
+    },
+    "favorites": {
+      "title": "Favoriten",
+      "empty": "Keine Daten für Favoriten vorhanden.",
+      "favorite-author": "Liebingsautor",
+      "first-five-star-book": "Erstes 5-Sterne Buch"
+    },
+    "books-per-year": {
+      "title": "Bücher pro Jahr",
+      "empty": "Es liegen keine Daten vor."
+    },
+    "books-per-month": {
+      "title": "Bücher pro Monat",
+      "empty": "Es liegen keine Daten vor."
     }
   },
   "no_thanks": "Nein danke",

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -84,6 +84,19 @@
     "timeline": "Timeline",
     "wishlist": "Wunschliste"
   },
+  "stats": {
+    "books-and-pages": {
+      "title": "Bücher & Seiten",
+      "empty": "Es liegen keine Daten vor.",
+      "books": "Bücher",
+      "books-waiting": "{} Bücher warten",
+      "books-reading": "{} Bücher werden gelesen",
+      "books-read": "{} Bücher gelesen",
+      "pages": "Seiten",
+      "pages-waiting": "{} Seiten warten",
+      "pages-read": "{} Seiten gelesen"
+    }
+  },
   "no_thanks": "Nein danke",
   "not_my_book": "Nicht mein Buch",
   "password": "Passwort",

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -95,6 +95,14 @@
       "pages": "Seiten",
       "pages-waiting": "{} Seiten warten",
       "pages-read": "{} Seiten gelesen"
+    },
+    "label": {
+      "title": "Labels",
+      "empty": "Es liegen keine Daten für Labels vor."
+    },
+    "language": {
+      "title": "Sprachen",
+      "empty": "Es liegen keine Daten für Sprachen vor."
     }
   },
   "no_thanks": "Nein danke",

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -98,7 +98,8 @@
     },
     "label": {
       "title": "Labels",
-      "empty": "Es liegen keine Daten für Labels vor."
+      "empty": "Es liegen keine Daten für Labels vor.",
+      "na": "NA"
     },
     "language": {
       "title": "Sprachen",

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -103,6 +103,13 @@
     "language": {
       "title": "Sprachen",
       "empty": "Es liegen keine Daten für Sprachen vor."
+    },
+    "reading-time": {
+      "title": "Lesezeit",
+      "empty": "Es liegen keine Daten vor.",
+      "fastest-book": "Schnellstes Buch",
+      "slowest-book": "Langsamstes Buch",
+      "days": "{} Tage"
     }
   },
   "no_thanks": "Nein danke",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -101,7 +101,8 @@
     },
     "language": {
       "title": "Languages",
-      "empty": "No data for language distribution."
+      "empty": "No data for language distribution.",
+      "na": "NA"
     },
     "reading-time": {
       "title": "Reading time",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -94,6 +94,14 @@
       "pages": "Pages",
       "pages-waiting": "{} pages waiting",
       "pages-read": "{} pages read"
+    },
+    "label": {
+      "title": "Labels",
+      "empty": "No data for label distribution."
+    },
+    "language": {
+      "title": "Languages",
+      "empty": "No data for language distribution."
     }
   },
   "no_thanks": "No thanks",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -110,6 +110,15 @@
       "fastest-book": "Fastest book",
       "slowest-book": "Slowest book",
       "days": "{} days"
+    },
+    "misc": {
+      "title": "Misc",
+      "average-books": {
+        "description": "Bücher per Month"
+      },
+      "most-read-month": {
+        "description": "Books in {}"
+      }
     }
   },
   "no_thanks": "No thanks",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -102,6 +102,13 @@
     "language": {
       "title": "Languages",
       "empty": "No data for language distribution."
+    },
+    "reading-time": {
+      "title": "Reading time",
+      "empty": "No data available.",
+      "fastest-book": "Fastest book",
+      "slowest-book": "Slowest book",
+      "days": "{} days"
     }
   },
   "no_thanks": "No thanks",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -83,6 +83,19 @@
     "timeline": "Timeline",
     "wishlist": "Wishlist"
   },
+  "stats": {
+    "books-and-pages": {
+      "title": "Books & Pages",
+      "empty": "No data available.",
+      "books": "Books",
+      "books-waiting": "{} books waiting",
+      "books-reading": "{} books reading",
+      "books-read": "{} books read",
+      "pages": "Pages",
+      "pages-waiting": "{} pages waiting",
+      "pages-read": "{} pages read"
+    }
+  },
   "no_thanks": "No thanks",
   "not_my_book": "Not my book",
   "password": "Password",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -113,12 +113,27 @@
     },
     "misc": {
       "title": "Misc",
+      "empty": "No data available.",
       "average-books": {
-        "description": "Bücher per Month"
+        "description": "Books per Month"
       },
       "most-read-month": {
         "description": "Books in {}"
       }
+    },
+    "favorites": {
+      "title": "Favorites",
+      "empty": "No data for favorites available.",
+      "favorite-author": "Favorite Author",
+      "first-five-star-book": "First 5-star rating"
+    },
+    "books-per-year": {
+      "title": "Books per year",
+      "empty": "No data available"
+    },
+    "books-per-month": {
+      "title": "Books per month",
+      "empty": "No data available"
     }
   },
   "no_thanks": "No thanks",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,50 +5,50 @@ PODS:
   - AppAuth/Core (1.6.2)
   - AppAuth/ExternalUserAgent (1.6.2):
     - AppAuth/Core
-  - Firebase/Analytics (10.16.0):
+  - Firebase/Analytics (10.18.0):
     - Firebase/Core
-  - Firebase/Auth (10.16.0):
+  - Firebase/Auth (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.16.0)
-  - Firebase/Core (10.16.0):
+    - FirebaseAuth (~> 10.18.0)
+  - Firebase/Core (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.16.0)
-  - Firebase/CoreOnly (10.16.0):
-    - FirebaseCore (= 10.16.0)
-  - Firebase/Crashlytics (10.16.0):
+    - FirebaseAnalytics (~> 10.18.0)
+  - Firebase/CoreOnly (10.18.0):
+    - FirebaseCore (= 10.18.0)
+  - Firebase/Crashlytics (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.16.0)
-  - Firebase/Database (10.16.0):
+    - FirebaseCrashlytics (~> 10.18.0)
+  - Firebase/Database (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.16.0)
-  - Firebase/Storage (10.16.0):
+    - FirebaseDatabase (~> 10.18.0)
+  - Firebase/Storage (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.16.0)
-  - firebase_analytics (10.6.3):
-    - Firebase/Analytics (= 10.16.0)
+    - FirebaseStorage (~> 10.18.0)
+  - firebase_analytics (10.7.2):
+    - Firebase/Analytics (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_auth (4.12.1):
-    - Firebase/Auth (= 10.16.0)
+  - firebase_auth (4.15.0):
+    - Firebase/Auth (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_core (2.21.0):
-    - Firebase/CoreOnly (= 10.16.0)
+  - firebase_core (2.24.0):
+    - Firebase/CoreOnly (= 10.18.0)
     - Flutter
-  - firebase_crashlytics (3.4.3):
-    - Firebase/Crashlytics (= 10.16.0)
+  - firebase_crashlytics (3.4.6):
+    - Firebase/Crashlytics (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_database (10.3.3):
-    - Firebase/Database (= 10.16.0)
+  - firebase_database (10.3.6):
+    - Firebase/Database (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_storage (11.4.1):
-    - Firebase/Storage (= 10.16.0)
+  - firebase_storage (11.5.3):
+    - Firebase/Storage (= 10.18.0)
     - firebase_core
     - Flutter
-  - FirebaseAnalytics (10.16.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.16.0)
+  - FirebaseAnalytics (10.18.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.18.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -56,33 +56,33 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.16.0):
+  - FirebaseAnalytics/AdIdSupport (10.18.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.16.0)
+    - GoogleAppMeasurement (= 10.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheckInterop (10.17.0)
-  - FirebaseAuth (10.16.0):
-    - FirebaseAppCheckInterop (~> 10.0)
+  - FirebaseAppCheckInterop (10.18.0)
+  - FirebaseAuth (10.18.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.17.0)
-  - FirebaseCore (10.16.0):
+  - FirebaseAuthInterop (10.18.0)
+  - FirebaseCore (10.18.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.17.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreExtension (10.18.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.17.0):
+  - FirebaseCoreInternal (10.18.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.16.0):
+  - FirebaseCrashlytics (10.18.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseSessions (~> 10.5)
@@ -90,16 +90,17 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.16.0):
-    - FirebaseAppCheckInterop (~> 10.16)
+  - FirebaseDatabase (10.18.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
+    - FirebaseSharedSwift (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseInstallations (10.17.0):
+  - FirebaseInstallations (10.18.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseSessions (10.17.0):
+  - FirebaseSessions (10.18.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -107,7 +108,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseStorage (10.16.0):
+  - FirebaseSharedSwift (10.18.0)
+  - FirebaseStorage (10.18.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -121,57 +123,57 @@ PODS:
   - FMDB/standard (2.7.5)
   - google_sign_in_ios (0.0.1):
     - Flutter
-    - GoogleSignIn (~> 7.0)
-  - GoogleAppMeasurement (10.16.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.16.0)
+    - GoogleSignIn (~> 6.2)
+  - GoogleAppMeasurement (10.18.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.16.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.16.0)
+  - GoogleAppMeasurement/AdIdSupport (10.18.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.16.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.18.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.2.5):
+  - GoogleDataTransport (9.3.0):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleSignIn (7.0.0):
+  - GoogleSignIn (6.2.4):
     - AppAuth (~> 1.5)
-    - GTMAppAuth (< 3.0, >= 1.3)
-    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.6):
+    - GTMAppAuth (~> 1.3)
+    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
+  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.6):
+  - GoogleUtilities/Environment (7.12.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.6):
+  - GoogleUtilities/Logger (7.12.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.6):
+  - GoogleUtilities/MethodSwizzler (7.12.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.6):
+  - GoogleUtilities/Network (7.12.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.6)"
-  - GoogleUtilities/Reachability (7.11.6):
+  - "GoogleUtilities/NSData+zlib (7.12.0)"
+  - GoogleUtilities/Reachability (7.12.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.6):
+  - GoogleUtilities/UserDefaults (7.12.0):
     - GoogleUtilities/Logger
-  - GTMAppAuth (2.0.0):
+  - GTMAppAuth (1.3.1):
     - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 4.0, >= 1.5)
+    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (2.3.0)
   - leveldb-library (1.22.2)
   - nanopb (2.30909.1):
@@ -225,6 +227,7 @@ SPEC REPOS:
     - FirebaseDatabase
     - FirebaseInstallations
     - FirebaseSessions
+    - FirebaseSharedSwift
     - FirebaseStorage
     - FMDB
     - GoogleAppMeasurement
@@ -269,34 +272,35 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  Firebase: 25899099b77d255a636e3579c3d9dce10ec150d5
-  firebase_analytics: 6b9cf6da9b2e38ace14482bd29e099b25abac4ad
-  firebase_auth: ff474dcf17bee5762106162e0791433024890ada
-  firebase_core: 68027ba03585e3efe1608e35d3ab2777a64eabe9
-  firebase_crashlytics: 8ca79ecf4713767f49730568dfc2f02ceaab52fd
-  firebase_database: f676aa735c93c83b465d1aa0f5a48b4d1f5a5200
-  firebase_storage: 39292d9729a2840035c6156fcec73168c7c234d4
-  FirebaseAnalytics: 7b41efc4eba5ff841cc94d5994b5f339361258f4
-  FirebaseAppCheckInterop: 534d033d8d0436b4ab066a8205013d271e18a2b9
-  FirebaseAuth: 3862d87d4d58deff08f705d471896a2f66e8bbf0
-  FirebaseAuthInterop: 86bc376e41419f2dc05c16aa42fe8301171a93aa
-  FirebaseCore: 65a801af84cca84361ef9eac3fd868656968a53b
-  FirebaseCoreExtension: 47720bb330d7041047c0935a34a3a4b92f818074
-  FirebaseCoreInternal: 2cf9202e226e3f78d2bf6d56c472686b935bfb7f
-  FirebaseCrashlytics: d7fe23c5796f21104c753446b7a51d1737a88fb9
-  FirebaseDatabase: c30143ba53120307f5c37d9ecb9acd780a1f7c55
-  FirebaseInstallations: 9387bf15abfc69a714f54e54f74a251264fdb79b
-  FirebaseSessions: 49f39e5c10e3f9fdd38d01b748329bae2a2fa8ed
-  FirebaseStorage: d664834746c0274d267072c6bfa100960f90654a
+  Firebase: 414ad272f8d02dfbf12662a9d43f4bba9bec2a06
+  firebase_analytics: a8c0d8ba83f213c9b775b5f61d36dadaafb1b239
+  firebase_auth: 02d1a6340f81020cc302fb8fea8518908c546cec
+  firebase_core: f802c5c1f6caff9b8d38b591a36e7b25f8878936
+  firebase_crashlytics: 0db78a5b6badc630f21a833d0c9ab20ab5d81948
+  firebase_database: 18b34a683c878f836ac5a403ce29242065d5acd0
+  firebase_storage: 95b470ab32351049dfd3d97b595460ce7a189971
+  FirebaseAnalytics: 4d310b35c48eaa4a058ddc04bdca6bdb5dc0fe80
+  FirebaseAppCheckInterop: 3cd914842ba46f4304050874cd284de82f154ffd
+  FirebaseAuth: 12314b438fa76048540c8fb86d6cfc9e08595176
+  FirebaseAuthInterop: 5818713dcd7239beb96c1125e4b14d6a5a910e5f
+  FirebaseCore: 2322423314d92f946219c8791674d2f3345b598f
+  FirebaseCoreExtension: 62b201498aa10535801cdf3448c7f4db5e24ed80
+  FirebaseCoreInternal: 8eb002e564b533bdcf1ba011f33f2b5c10e2ed4a
+  FirebaseCrashlytics: 86d5bce01f42fa1db265f87ff1d591f04db610ec
+  FirebaseDatabase: ac770bf7525ff0340b105166037036c0e46c2c7e
+  FirebaseInstallations: e842042ec6ac1fd2e37d7706363ebe7f662afea4
+  FirebaseSessions: f90fe9212ee2818641eda051c0835c9c4e30d9ae
+  FirebaseSharedSwift: 62e248642c0582324d0390706cadd314687c116b
+  FirebaseStorage: 8333c4b183764cdd170d9539a61322b71c23adff
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_barcode_scanner: 7a1144744c28dc0c57a8de7218ffe5ec59a9e4bf
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  google_sign_in_ios: 8115e3fbe097e6509beb819ed602d47369d9011f
-  GoogleAppMeasurement: 079d7632810e9d9704a99932547ba1554acc4342
-  GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
-  GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
-  GoogleUtilities: 202e7a9f5128accd11160fb9c19612de1911aa19
-  GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
+  google_sign_in_ios: 1256ff9d941db546373826966720b0c24804bcdd
+  GoogleAppMeasurement: 70ce9aa438cff1cfb31ea3e660bcc67734cb716e
+  GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
+  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
+  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
+  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
@@ -306,7 +310,7 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
-  url_launcher_ios: 68d46cc9766d0c41dbdc884310529557e3cd7a86
+  url_launcher_ios: bf5ce03e0e2088bad9cc378ea97fa0ed5b49673b
 
 PODFILE CHECKSUM: 7adbc9d59f05e1b01f554ea99b6c79e97f2214a2
 

--- a/lib/src/data/isbn/barcode_isbn_scanner_service.dart
+++ b/lib/src/data/isbn/barcode_isbn_scanner_service.dart
@@ -1,6 +1,5 @@
 import 'package:dantex/src/data/isbn/isbn_scanner_service.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
 
 class BarcodeIsbnScannerService implements IsbnScannerService {

--- a/lib/src/data/isbn/barcode_isbn_scanner_service.dart
+++ b/lib/src/data/isbn/barcode_isbn_scanner_service.dart
@@ -5,7 +5,7 @@ import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
 
 class BarcodeIsbnScannerService implements IsbnScannerService {
   @override
-  Future<String> scanIsbn(BuildContext context) {
+  Future<String> scanIsbn() {
     return FlutterBarcodeScanner.scanBarcode(
       '#00000000', // Transparent line
       'cancel'.tr(),

--- a/lib/src/data/isbn/isbn_scanner_service.dart
+++ b/lib/src/data/isbn/isbn_scanner_service.dart
@@ -1,8 +1,3 @@
-
-
-import 'package:flutter/cupertino.dart';
-
 abstract class IsbnScannerService {
-
-  Future<String> scanIsbn(BuildContext context);
+  Future<String> scanIsbn();
 }

--- a/lib/src/data/stats/default_stats_builder.dart
+++ b/lib/src/data/stats/default_stats_builder.dart
@@ -18,7 +18,7 @@ class DefaultStatsBuilder implements StatsBuilder {
   List<StatsItem> _buildStatsItems(List<Book> books) {
     return _itemBuilders
         .map(
-          (builder) => builder.build(books),
+          (builder) => builder.buildStatsItem(books),
         )
         .toList();
   }

--- a/lib/src/data/stats/default_stats_builder.dart
+++ b/lib/src/data/stats/default_stats_builder.dart
@@ -1,0 +1,25 @@
+import 'package:dantex/src/data/book/book_repository.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class DefaultStatsBuilder implements StatsBuilder {
+  final BookRepository _bookRepository;
+  final List<StatsItemBuilder> _itemBuilders;
+
+  DefaultStatsBuilder(this._bookRepository, this._itemBuilders);
+
+  @override
+  Stream<List<StatsItem>> buildStats() {
+    return _bookRepository.getAllBooks().map(_buildStatsItems);
+  }
+
+  List<StatsItem> _buildStatsItems(List<Book> books) {
+    return _itemBuilders
+        .map(
+          (builder) => builder.build(books),
+        )
+        .toList();
+  }
+}

--- a/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
@@ -1,0 +1,56 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class BooksAndPagesStatsItemBuilder implements StatsItemBuilder {
+  @override
+  StatsItem build(List<Book> books) {
+    final BooksAndPagesDataState dataState;
+    if (books.isEmpty) {
+      dataState = EmptyBooksAndPagesData();
+    } else {
+      dataState = _buildPresentDataState(books);
+    }
+
+    return BooksAndPagesStatsItem(dataState);
+  }
+
+  BooksAndPagesDataState _buildPresentDataState(List<Book> books) {
+    final Map<BookState, List<Book>> bookStates = books.groupListsBy(
+      (b) => b.state,
+    );
+
+    final List<Book> booksWaiting = bookStates[BookState.readLater] ?? [];
+    final List<Book> booksReading = bookStates[BookState.reading] ?? [];
+    final List<Book> booksRead = bookStates[BookState.read] ?? [];
+
+    final int pagesRead = booksRead.fold(
+          0,
+          (previousValue, element) => previousValue + element.pageCount,
+        ) +
+        booksReading.fold(
+          0,
+          (previousValue, element) => previousValue + element.currentPage,
+        );
+
+    final int pagesWaiting = booksWaiting.fold(
+          0,
+          (previousValue, element) => previousValue + element.pageCount,
+        ) +
+        booksReading.fold(
+          0,
+          (previousValue, element) =>
+              previousValue + (element.pageCount - element.currentPage),
+        );
+
+    return BooksAndPagesData(
+      booksWaiting: booksWaiting.length,
+      booksReading: booksReading.length,
+      booksRead: booksRead.length,
+      pagesRead: pagesRead,
+      pagesWaiting: pagesWaiting,
+    );
+  }
+}

--- a/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
@@ -4,9 +4,9 @@ import 'package:dantex/src/data/book/entity/book_state.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
-class BooksAndPagesStatsItemBuilder implements StatsItemBuilder {
+class BooksAndPagesStatsItemBuilder implements StatsItemBuilder<BooksAndPagesStatsItem> {
   @override
-  StatsItem buildStatsItem(List<Book> books) {
+  BooksAndPagesStatsItem buildStatsItem(List<Book> books) {
     final BooksAndPagesDataState dataState;
     if (books.isEmpty) {
       dataState = EmptyBooksAndPagesData();

--- a/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart
@@ -6,7 +6,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 
 class BooksAndPagesStatsItemBuilder implements StatsItemBuilder {
   @override
-  StatsItem build(List<Book> books) {
+  StatsItem buildStatsItem(List<Book> books) {
     final BooksAndPagesDataState dataState;
     if (books.isEmpty) {
       dataState = EmptyBooksAndPagesData();

--- a/lib/src/data/stats/item_builder/books_per_month_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/books_per_month_stats_item_builder.dart
@@ -1,0 +1,40 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/util/extensions.dart';
+
+class BooksPerMonthStatsItemBuilder
+    extends StatsItemBuilder<BooksPerMonthStatsItem> {
+  @override
+  BooksPerMonthStatsItem buildStatsItem(List<Book> books) {
+    final List<Book> readBooks = books.filterReadBooks();
+
+    final BooksPerMonthDataState dataState = readBooks.isEmpty
+        ? EmptyBooksPerMonthData()
+        : _buildBooksPerMonthData(readBooks);
+
+    return BooksPerMonthStatsItem(dataState);
+  }
+
+  BooksPerMonthData _buildBooksPerMonthData(final List<Book> books) {
+    final Map<DateTime, int> booksPerMonthDistribution = Map.fromEntries(
+      books
+          .groupListsBy(
+            (book) {
+              final DateTime endTime = book.endDate!;
+              return DateTime(endTime.year, endTime.month);
+            },
+          )
+          .entries
+          .sorted((a, b) => a.key.difference(b.key).inDays)
+          .map(
+            (e) => MapEntry(e.key, e.value.length),
+          ),
+    );
+
+    return BooksPerMonthData(
+      booksPerMonthDistribution: booksPerMonthDistribution,
+    );
+  }
+}

--- a/lib/src/data/stats/item_builder/books_per_year_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/books_per_year_stats_item_builder.dart
@@ -1,0 +1,33 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/util/extensions.dart';
+
+class BooksPerYearStatsItemBuilder
+    extends StatsItemBuilder<BooksPerYearStatsItem> {
+  @override
+  BooksPerYearStatsItem buildStatsItem(List<Book> books) {
+    final List<Book> readBooks = books.filterReadBooks();
+
+    final BooksPerYearDataState dataState = readBooks.isEmpty
+        ? EmptyBooksPerYearData()
+        : _buildBooksPerYearData(readBooks);
+
+    return BooksPerYearStatsItem(dataState);
+  }
+
+  BooksPerYearData _buildBooksPerYearData(final List<Book> books) {
+    final Map<int, int> booksPerYearDistribution = Map.fromEntries(
+      books
+          .groupListsBy((book) => book.endDate!.year)
+          .entries
+          .sorted((a, b) => a.key - b.key)
+          .map(
+            (e) => MapEntry(e.key, e.value.length),
+          ),
+    );
+
+    return BooksPerYearData(booksPerYearDistribution: booksPerYearDistribution);
+  }
+}

--- a/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/util/extensions.dart';
 
 class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
   @override
@@ -32,8 +33,7 @@ class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
   Book? _firstFiveStarRating(List<Book> books) {
     return books
         .where((book) => book.rating == 5 && book.startDate != null)
-        .sorted((a, b) =>
-            a.startDate?.compareTo(b.startDate ?? DateTime.now()) ?? -1)
+        .sortedByStartDate()
         .firstOrNull;
   }
 }

--- a/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
@@ -31,9 +31,6 @@ class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
   }
 
   Book? _firstFiveStarRating(List<Book> books) {
-
-    return books.first;
-
     return books
         .where((book) => book.rating == 5 && book.startDate != null)
         .sortedByStartDate()

--- a/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
@@ -31,6 +31,9 @@ class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
   }
 
   Book? _firstFiveStarRating(List<Book> books) {
+
+    return books.first;
+
     return books
         .where((book) => book.rating == 5 && book.startDate != null)
         .sortedByStartDate()

--- a/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
@@ -24,7 +24,7 @@ class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
     return books
             .groupListsBy((e) => e.author)
             .entries
-            .sorted((a, b) => a.value.length - b.value.length)
+            .sorted((a, b) => b.value.length - a.value.length)
             .firstOrNull
             ?.value ??
         [];

--- a/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/favorites_stats_item_builder.dart
@@ -1,0 +1,39 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class FavoritesStatsItemBuilder extends StatsItemBuilder<FavoritesStatsItem> {
+  @override
+  FavoritesStatsItem buildStatsItem(List<Book> books) {
+    final List<Book> favoriteAuthor = _favoriteAuthor(books);
+    final Book? firstFiveStarRating = _firstFiveStarRating(books);
+
+    final FavoritesDataState dataState = favoriteAuthor.isEmpty
+        ? EmptyFavoritesData()
+        : FavoritesData(
+            favoriteAuthor: favoriteAuthor,
+            firstFiveStarBook: firstFiveStarRating,
+          );
+
+    return FavoritesStatsItem(dataState);
+  }
+
+  List<Book> _favoriteAuthor(List<Book> books) {
+    return books
+            .groupListsBy((e) => e.author)
+            .entries
+            .sorted((a, b) => a.value.length - b.value.length)
+            .firstOrNull
+            ?.value ??
+        [];
+  }
+
+  Book? _firstFiveStarRating(List<Book> books) {
+    return books
+        .where((book) => book.rating == 5 && book.startDate != null)
+        .sorted((a, b) =>
+            a.startDate?.compareTo(b.startDate ?? DateTime.now()) ?? -1)
+        .firstOrNull;
+  }
+}

--- a/lib/src/data/stats/item_builder/label_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/label_stats_item_builder.dart
@@ -23,6 +23,10 @@ class LabelStatsItemBuilder implements StatsItemBuilder<LabelStatsItem> {
         .groupListsBy((element) => element.title)
         .map((key, value) => MapEntry(key, value.length));
 
+    if (distribution.isEmpty) {
+      return EmptyLabelData();
+    }
+
     return LabelData(labelDistribution: distribution);
   }
 }

--- a/lib/src/data/stats/item_builder/label_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/label_stats_item_builder.dart
@@ -1,0 +1,28 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class LabelStatsItemBuilder implements StatsItemBuilder<LabelStatsItem> {
+  @override
+  LabelStatsItem buildStatsItem(List<Book> books) {
+    final LabelDataState dataState;
+    if (books.isEmpty) {
+      dataState = EmptyLabelData();
+    } else {
+      dataState = _buildLabelDataState(books);
+    }
+
+    return LabelStatsItem(dataState);
+  }
+
+  LabelDataState _buildLabelDataState(List<Book> books) {
+    final Map<String, int> distribution = books
+        .map((e) => e.labels)
+        .flattened
+        .groupListsBy((element) => element.title)
+        .map((key, value) => MapEntry(key, value.length));
+
+    return LabelData(labelDistribution: distribution);
+  }
+}

--- a/lib/src/data/stats/item_builder/language_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/language_stats_item_builder.dart
@@ -1,0 +1,26 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class LanguageStatsItemBuilder implements StatsItemBuilder<LanguageStatsItem> {
+  @override
+  LanguageStatsItem buildStatsItem(List<Book> books) {
+    final LanguageDataState dataState;
+    if (books.isEmpty) {
+      dataState = EmptyLanguageData();
+    } else {
+      dataState = _buildLanguageDataState(books);
+    }
+
+    return LanguageStatsItem(dataState);
+  }
+
+  LanguageDataState _buildLanguageDataState(List<Book> books) {
+    final Map<String, int> distribution = books
+        .groupListsBy((e) => e.language)
+        .map((key, value) => MapEntry(key, value.length));
+
+    return LanguageData(languageDistribution: distribution);
+  }
+}

--- a/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
@@ -1,0 +1,69 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/util/extensions.dart';
+import 'package:easy_localization/easy_localization.dart';
+
+class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
+  @override
+  MiscStatsItem buildStatsItem(List<Book> books) {
+    final MiscDataState dataState =
+        books.isEmpty ? EmptyMiscData() : _buildMiscData(books);
+
+    return MiscStatsItem(dataState);
+  }
+
+  MiscData _buildMiscData(List<Book> books) {
+    return MiscData(
+      averageBooksPerMonth: _averageBooksPerMonth(books),
+      mostActiveMonth: _mostActiveMonth(books),
+    );
+  }
+
+  double _averageBooksPerMonth(List<Book> books) {
+    final List<Book> doneBooks = books
+        .where(
+          (book) => book.startDate != null && book.state == BookState.read,
+        )
+        .sortedByStartDate();
+
+    final DateTime start = doneBooks.firstOrNull?.startDate ?? DateTime.now();
+
+    // Unfortunately Dart does not offer a `inMonths` method, so just divide
+    // the output by 30. That will give a close enough estimate.
+    final int monthsReading =
+        (start.difference(DateTime.now()).inDays / 30) as int;
+
+    if (monthsReading == 0) {
+      return doneBooks.length.toDouble();
+    } else {
+      return doneBooks.length / monthsReading.toDouble();
+    }
+  }
+
+  MostActiveMonth? _mostActiveMonth(List<Book> books) {
+    final List<Book> booksOfMostReadMonth = books
+            .where((book) => book.state == BookState.read)
+            .groupListsBy(
+              (book) => '${book.endDate!.month}-${book.endDate!.year}',
+            )
+            .entries
+            .sorted((a, b) => a.value.length - b.value.length)
+            .firstOrNull
+            ?.value ??
+        [];
+
+    if (booksOfMostReadMonth.isEmpty) {
+      return null;
+    }
+
+    final DateTime date = booksOfMostReadMonth.first.endDate!;
+    return MostActiveMonth(
+      formattedMonthAndYear:
+          DateFormat(DateFormat.YEAR_ABBR_MONTH).format(date),
+      books: booksOfMostReadMonth,
+    );
+  }
+}

--- a/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
@@ -4,9 +4,13 @@ import 'package:dantex/src/data/book/entity/book_state.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/util/extensions.dart';
-import 'package:easy_localization/easy_localization.dart';
 
 class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
+
+  final DateTime _currentDateTime;
+
+  MiscStatsItemBuilder(this._currentDateTime);
+
   @override
   MiscStatsItem buildStatsItem(List<Book> books) {
     final MiscDataState dataState =
@@ -30,11 +34,13 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
         .sortedByStartDate();
 
     final DateTime start = doneBooks.firstOrNull?.startDate ?? DateTime.now();
+    final DateTime startCorrected = DateTime(start.year, start.month);
 
     // Unfortunately Dart does not offer a `inMonths` method, so just divide
-    // the output by 30. That will give a close enough estimate.
-    final int monthsReading =
-        (start.difference(DateTime.now()).inDays / 30) as int;
+    // the output by 30 and add +1 (+1 because of the last month, as it just
+    // started, but the days are not added to the datetime).
+    // That will give a close enough estimate.
+    final int monthsReading = (_currentDateTime.difference(startCorrected).inDays ~/ 30) + 1;
 
     if (monthsReading == 0) {
       return doneBooks.length.toDouble();
@@ -50,7 +56,7 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
               (book) => '${book.endDate!.month}-${book.endDate!.year}',
             )
             .entries
-            .sorted((a, b) => a.value.length - b.value.length)
+            .sorted((a, b) => b.value.length - a.value.length)
             .firstOrNull
             ?.value ??
         [];
@@ -59,10 +65,12 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
       return null;
     }
 
-    final DateTime date = booksOfMostReadMonth.first.endDate!;
+    final DateTime date = DateTime(
+      booksOfMostReadMonth.first.endDate!.year,
+      booksOfMostReadMonth.first.endDate!.month,
+    );
     return MostActiveMonth(
-      formattedMonthAndYear:
-          DateFormat(DateFormat.YEAR_ABBR_MONTH).format(date),
+      month: date,
       books: booksOfMostReadMonth,
     );
   }

--- a/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/misc_stats_item_builder.dart
@@ -6,7 +6,6 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/util/extensions.dart';
 
 class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
-
   final DateTime _currentDateTime;
 
   MiscStatsItemBuilder(this._currentDateTime);
@@ -33,6 +32,10 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
         )
         .sortedByStartDate();
 
+    if (doneBooks.isEmpty) {
+      return 0;
+    }
+
     final DateTime start = doneBooks.firstOrNull?.startDate ?? DateTime.now();
     final DateTime startCorrected = DateTime(start.year, start.month);
 
@@ -40,7 +43,8 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
     // the output by 30 and add +1 (+1 because of the last month, as it just
     // started, but the days are not added to the datetime).
     // That will give a close enough estimate.
-    final int monthsReading = (_currentDateTime.difference(startCorrected).inDays ~/ 30) + 1;
+    final int monthsReading =
+        (_currentDateTime.difference(startCorrected).inDays ~/ 30) + 1;
 
     if (monthsReading == 0) {
       return doneBooks.length.toDouble();
@@ -51,7 +55,9 @@ class MiscStatsItemBuilder extends StatsItemBuilder<MiscStatsItem> {
 
   MostActiveMonth? _mostActiveMonth(List<Book> books) {
     final List<Book> booksOfMostReadMonth = books
-            .where((book) => book.state == BookState.read)
+            .where(
+              (book) => book.state == BookState.read && book.endDate != null,
+            )
             .groupListsBy(
               (book) => '${book.endDate!.month}-${book.endDate!.year}',
             )

--- a/lib/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart
@@ -7,7 +7,6 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 class PagesPerMonthStatsItemBuilder implements StatsItemBuilder<PagesPerMonthStatsItem> {
   @override
   PagesPerMonthStatsItem buildStatsItem(List<Book> books) {
-    // TODO: implement buildStatsItem
     return PagesPerMonthStatsItem();
   }
 

--- a/lib/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart
@@ -1,0 +1,14 @@
+
+
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class PagesPerMonthStatsItemBuilder implements StatsItemBuilder<PagesPerMonthStatsItem> {
+  @override
+  PagesPerMonthStatsItem buildStatsItem(List<Book> books) {
+    // TODO: implement buildStatsItem
+    return PagesPerMonthStatsItem();
+  }
+
+}

--- a/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
@@ -4,7 +4,8 @@ import 'package:dantex/src/data/book/entity/book_state.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
-class ReadingTimeStatsItemBuilder implements StatsItemBuilder<ReadingTimeStatsItem> {
+class ReadingTimeStatsItemBuilder
+    implements StatsItemBuilder<ReadingTimeStatsItem> {
   @override
   ReadingTimeStatsItem buildStatsItem(List<Book> books) {
     final ReadingTimeDataState dataState;
@@ -21,7 +22,9 @@ class ReadingTimeStatsItemBuilder implements StatsItemBuilder<ReadingTimeStatsIt
     final List<Book> finishedSortedBooks = books
         .where(
           (element) =>
-              element.state == BookState.read && element.startDate != null,
+              element.state == BookState.read &&
+              element.startDate != null &&
+              element.endDate != null,
         )
         .sorted(
           (a, b) =>

--- a/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
@@ -1,0 +1,14 @@
+
+
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+class ReadingTimeStatsItemBuilder implements StatsItemBuilder {
+  @override
+  StatsItem build(List<Book> books) {
+    // TODO: implement build
+    throw UnimplementedError();
+  }
+
+}

--- a/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
@@ -1,14 +1,41 @@
-
-
+import 'package:collection/collection.dart';
 import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
-class ReadingTimeStatsItemBuilder implements StatsItemBuilder {
+class ReadingTimeStatsItemBuilder implements StatsItemBuilder<ReadingTimeStatsItem> {
   @override
-  StatsItem buildStatsItem(List<Book> books) {
-    // TODO: implement build
-    throw UnimplementedError();
+  ReadingTimeStatsItem buildStatsItem(List<Book> books) {
+    final ReadingTimeDataState dataState;
+    if (books.isEmpty) {
+      dataState = EmptyReadingTimeData();
+    } else {
+      dataState = _buildReadingTimeDataState(books);
+    }
+
+    return ReadingTimeStatsItem(dataState);
   }
 
+  ReadingTimeDataState _buildReadingTimeDataState(List<Book> books) {
+    final List<Book> finishedSortedBooks = books
+        .where(
+          (element) =>
+              element.state == BookState.read && element.startDate != null,
+        )
+        .sorted(
+          (a, b) =>
+              a.endDate!.difference(a.startDate!).inDays -
+              b.endDate!.difference(b.startDate!).inDays,
+        );
+
+    if (finishedSortedBooks.isEmpty) {
+      return EmptyReadingTimeData();
+    }
+
+    return ReadingTimeData(
+      fastestBook: finishedSortedBooks.first,
+      slowestBook: finishedSortedBooks.last,
+    );
+  }
 }

--- a/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/reading_time_stats_item_builder.dart
@@ -6,7 +6,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 
 class ReadingTimeStatsItemBuilder implements StatsItemBuilder {
   @override
-  StatsItem build(List<Book> books) {
+  StatsItem buildStatsItem(List<Book> books) {
     // TODO: implement build
     throw UnimplementedError();
   }

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -3,29 +3,30 @@ import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
 /// TODO Required subclasses
-/// -[ ] Favorites (favorite author + first 5 star rating)
-///   -[x] Logic
-///   -[ ] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
+/// -[ ] BUG WHEN MOVING BOOKS BETWEEN STATES
 /// -[ ] Books per Year
 ///   -[x] Logic
 ///   -[ ] UI
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
 /// -[ ] Books per Month
-///   -[ ] Logic
+///   -[x] Logic
 ///   -[ ] UI
-///   -[ ] Goals
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
+/// -[ ] Update pub dependencies
+///
+/// TODO: OWN TICKET BC OF PAGE REPOSITORY
 /// -[ ] Pages per Month
 ///   -[ ] Logic
 ///   -[ ] UI
-///   -[ ] Goals
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
-/// -[ ] BUG WHEN MOVING BOOKS
+///
+/// -[ ] Books per Month
+///   -[ ] Goals
+/// -[ ] Pages per Month
+///   -[ ] Goals
 abstract class StatsItemBuilder<T extends StatsItem> {
 
   T buildStatsItem(List<Book> books);

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -3,16 +3,25 @@ import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
 /// TODO Required subclasses
-/// -[x] Books and Pages Diagram (PieChart)
-/// -[ ] Pages per Month (including goal)
-/// -[ ] Books per Month (including goals)
+/// -[x] Books and Pages
+///   -[x] UI: PieChart
+/// -[x] Languages
+///   -[x] UI: PieChart
+/// -[x] Labels
+///   -[ ] UI: RadarChart
+/// -[x] Reading time (fastest, slowest book)
+///   -[ ] UI
+/// -[ ] Pages per Month
+///   -[ ] UI (including goals)
+/// -[ ] Books per Month
+///   -[ ] UI (including goals)
 /// -[ ] Books per Year
-/// -[ ] Reading time (fastest, slowest book)
+///   -[ ] UI
 /// -[ ] Favorites (favorite author + first 5 star rating)
-/// -[ ] Languages (Pie Chart)
-/// -[ ] Labels (RadarChart)
+///   -[ ] UI
 /// -[ ] Book Per Months stats (most read books in month, average books per month)
-abstract class StatsItemBuilder {
+///   -[ ] UI
+abstract class StatsItemBuilder<T extends StatsItem> {
 
-  StatsItem buildStatsItem(List<Book> books);
+  T buildStatsItem(List<Book> books);
 }

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -1,0 +1,18 @@
+
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+/// TODO Required subclasses
+/// -[x] Books and Pages Diagram (PieChart)
+/// -[ ] Pages per Month (including goal)
+/// -[ ] Books per Month (including goals)
+/// -[ ] Books per Year
+/// -[ ] Reading time (fastest, slowest book)
+/// -[ ] Favorites (favorite author + first 5 star rating)
+/// -[ ] Languages (Pie Chart)
+/// -[ ] Labels (RadarChart)
+/// -[ ] Book Per Months stats (most read books in month, average books per month)
+abstract class StatsItemBuilder {
+
+  StatsItem build(List<Book> books);
+}

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -2,31 +2,6 @@
 import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
-/// TODO Required subclasses
-/// -[ ] BUG WHEN MOVING BOOKS BETWEEN STATES
-/// -[ ] Books per Year
-///   -[x] Logic
-///   -[ ] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
-/// -[ ] Books per Month
-///   -[x] Logic
-///   -[ ] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
-/// -[ ] Update pub dependencies
-///
-/// TODO: OWN TICKET BC OF PAGE REPOSITORY
-/// -[ ] Pages per Month
-///   -[ ] Logic
-///   -[ ] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
-///
-/// -[ ] Books per Month
-///   -[ ] Goals
-/// -[ ] Pages per Month
-///   -[ ] Goals
 abstract class StatsItemBuilder<T extends StatsItem> {
 
   T buildStatsItem(List<Book> books);

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -3,28 +3,8 @@ import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
 /// TODO Required subclasses
-/// -[x] Books and Pages
-///   -[x] Logic
-///   -[x] UI: PieChart
-///   -[x] Dark Mode
-///   -[x] Mobile Layout
-/// -[x] Languages
-///   -[x] Logic
-///   -[x] UI: PieChart
-///   -[x] Dark Mode
-///   -[x] Mobile Layout
-/// -[x] Labels
-///   -[x] Logic
-///   -[x] UI: RadarChart
-///   -[x] Dark Mode
-///   -[x] Mobile Layout
-/// -[x] Reading time (fastest, slowest book)
-///   -[x] Logic
-///   -[x] UI
-///   -[x] Dark Mode
-///   -[x] Mobile Layout
 /// -[ ] Misc stats (most read books in month, average books per month)
-///   -[x] Logic
+///   -[~] Logic
 ///   -[ ] UI
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -18,8 +18,8 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[ ] Favorites (favorite author + first 5 star rating)
 ///   -[x] Logic
 ///   -[ ] UI
-/// -[ ] Book Per Months stats (most read books in month, average books per month)
-///   -[ ] Logic
+/// -[ ] Misc stats (most read books in month, average books per month)
+///   -[x] Logic
 ///   -[ ] UI
 /// -[ ] Pages per Month
 ///   -[ ] Logic

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -11,24 +11,24 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[x] Languages
 ///   -[x] Logic
 ///   -[x] UI: PieChart
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
+///   -[x] Dark Mode
+///   -[x] Mobile Layout
 /// -[x] Labels
 ///   -[x] Logic
 ///   -[x] UI: RadarChart
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
+///   -[x] Dark Mode
+///   -[x] Mobile Layout
 /// -[x] Reading time (fastest, slowest book)
 ///   -[x] Logic
 ///   -[x] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
-/// -[ ] Favorites (favorite author + first 5 star rating)
+///   -[x] Dark Mode
+///   -[x] Mobile Layout
+/// -[ ] Misc stats (most read books in month, average books per month)
 ///   -[x] Logic
 ///   -[ ] UI
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
-/// -[ ] Misc stats (most read books in month, average books per month)
+/// -[ ] Favorites (favorite author + first 5 star rating)
 ///   -[x] Logic
 ///   -[ ] UI
 ///   -[ ] Dark Mode

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -6,32 +6,50 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[x] Books and Pages
 ///   -[x] Logic
 ///   -[x] UI: PieChart
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[x] Languages
 ///   -[x] Logic
 ///   -[x] UI: PieChart
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[x] Labels
 ///   -[x] Logic
 ///   -[x] UI: RadarChart
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[x] Reading time (fastest, slowest book)
 ///   -[x] Logic
 ///   -[x] UI
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[ ] Favorites (favorite author + first 5 star rating)
 ///   -[x] Logic
 ///   -[ ] UI
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[ ] Misc stats (most read books in month, average books per month)
 ///   -[x] Logic
 ///   -[ ] UI
-/// -[ ] Pages per Month
-///   -[ ] Logic
-///   -[ ] UI
-///   -[ ] Goals
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[ ] Books per Month
 ///   -[ ] Logic
 ///   -[ ] UI
 ///   -[ ] Goals
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[ ] Books per Year
+///   -[x] Logic
+///   -[ ] UI
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
+/// -[ ] Pages per Month
 ///   -[ ] Logic
 ///   -[ ] UI
+///   -[ ] Goals
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 abstract class StatsItemBuilder<T extends StatsItem> {
 
   T buildStatsItem(List<Book> books);

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -6,8 +6,8 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[x] Books and Pages
 ///   -[x] Logic
 ///   -[x] UI: PieChart
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
+///   -[x] Dark Mode
+///   -[x] Mobile Layout
 /// -[x] Languages
 ///   -[x] Logic
 ///   -[x] UI: PieChart
@@ -33,15 +33,15 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 ///   -[ ] UI
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
+/// -[ ] Books per Year
+///   -[x] Logic
+///   -[ ] UI
+///   -[ ] Dark Mode
+///   -[ ] Mobile Layout
 /// -[ ] Books per Month
 ///   -[ ] Logic
 ///   -[ ] UI
 ///   -[ ] Goals
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
-/// -[ ] Books per Year
-///   -[x] Logic
-///   -[ ] UI
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
 /// -[ ] Pages per Month

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -14,5 +14,5 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[ ] Book Per Months stats (most read books in month, average books per month)
 abstract class StatsItemBuilder {
 
-  StatsItem build(List<Book> books);
+  StatsItem buildStatsItem(List<Book> books);
 }

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -4,23 +4,33 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 
 /// TODO Required subclasses
 /// -[x] Books and Pages
+///   -[x] Logic
 ///   -[x] UI: PieChart
 /// -[x] Languages
+///   -[x] Logic
 ///   -[x] UI: PieChart
 /// -[x] Labels
+///   -[x] Logic
 ///   -[x] UI: RadarChart
 /// -[x] Reading time (fastest, slowest book)
+///   -[x] Logic
 ///   -[x] UI
 /// -[ ] Favorites (favorite author + first 5 star rating)
+///   -[x] Logic
 ///   -[ ] UI
 /// -[ ] Book Per Months stats (most read books in month, average books per month)
+///   -[ ] Logic
 ///   -[ ] UI
-///
 /// -[ ] Pages per Month
-///   -[ ] UI (including goals)
+///   -[ ] Logic
+///   -[ ] UI
+///   -[ ] Goals
 /// -[ ] Books per Month
-///   -[ ] UI (including goals)
+///   -[ ] Logic
+///   -[ ] UI
+///   -[ ] Goals
 /// -[ ] Books per Year
+///   -[ ] Logic
 ///   -[ ] UI
 abstract class StatsItemBuilder<T extends StatsItem> {
 

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -3,11 +3,6 @@ import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
 
 /// TODO Required subclasses
-/// -[ ] Misc stats (most read books in month, average books per month)
-///   -[~] Logic
-///   -[ ] UI
-///   -[ ] Dark Mode
-///   -[ ] Mobile Layout
 /// -[ ] Favorites (favorite author + first 5 star rating)
 ///   -[x] Logic
 ///   -[ ] UI
@@ -30,6 +25,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 ///   -[ ] Goals
 ///   -[ ] Dark Mode
 ///   -[ ] Mobile Layout
+/// -[ ] BUG WHEN MOVING BOOKS
 abstract class StatsItemBuilder<T extends StatsItem> {
 
   T buildStatsItem(List<Book> books);

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -8,18 +8,19 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[x] Languages
 ///   -[x] UI: PieChart
 /// -[x] Labels
-///   -[ ] UI: RadarChart
+///   -[x] UI: RadarChart
 /// -[x] Reading time (fastest, slowest book)
 ///   -[ ] UI
+/// -[ ] Favorites (favorite author + first 5 star rating)
+///   -[ ] UI
+/// -[ ] Book Per Months stats (most read books in month, average books per month)
+///   -[ ] UI
+///
 /// -[ ] Pages per Month
 ///   -[ ] UI (including goals)
 /// -[ ] Books per Month
 ///   -[ ] UI (including goals)
 /// -[ ] Books per Year
-///   -[ ] UI
-/// -[ ] Favorites (favorite author + first 5 star rating)
-///   -[ ] UI
-/// -[ ] Book Per Months stats (most read books in month, average books per month)
 ///   -[ ] UI
 abstract class StatsItemBuilder<T extends StatsItem> {
 

--- a/lib/src/data/stats/item_builder/stats_item_builder.dart
+++ b/lib/src/data/stats/item_builder/stats_item_builder.dart
@@ -10,7 +10,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 /// -[x] Labels
 ///   -[x] UI: RadarChart
 /// -[x] Reading time (fastest, slowest book)
-///   -[ ] UI
+///   -[x] UI
 /// -[ ] Favorites (favorite author + first 5 star rating)
 ///   -[ ] UI
 /// -[ ] Book Per Months stats (most read books in month, average books per month)

--- a/lib/src/data/stats/stats_builder.dart
+++ b/lib/src/data/stats/stats_builder.dart
@@ -1,0 +1,8 @@
+
+
+import 'package:dantex/src/data/stats/stats_item.dart';
+
+abstract class StatsBuilder {
+
+  Stream<List<StatsItem>> buildStats();
+}

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -54,9 +54,8 @@ class ReadingTimeStatsItem extends StatsItem {
 
   ReadingTimeStatsItem(this.dataState);
 
-  // TODO Translate
   @override
-  String get titleKey => 'Reading Time';
+  String get titleKey => 'stats.reading-time.title';
 
   @override
   ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -123,6 +123,32 @@ class LabelData extends LabelDataState {
   });
 }
 
+class FavoritesStatsItem extends StatsItem {
+
+  final FavoritesDataState dataState;
+
+  FavoritesStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 2, height: 1);
+
+  @override
+  String get titleKey => 'stats.favorites.title';
+}
+sealed class FavoritesDataState {}
+
+class EmptyFavoritesData extends FavoritesDataState {}
+
+class FavoritesData extends FavoritesDataState {
+  final List<Book> favoriteAuthor;
+  final Book? firstFiveStarBook;
+
+  FavoritesData({
+    required this.favoriteAuthor,
+    required this.firstFiveStarBook,
+  });
+}
+
 class PagesPerMonthStatsItem extends StatsItem {
   @override
   ItemDesktopSize get desktopSize => ItemDesktopSize(width: 3, height: 1);

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -1,4 +1,7 @@
 import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'stats_item.freezed.dart';
 
 class ItemDesktopSize {
   final int width;
@@ -139,14 +142,13 @@ sealed class FavoritesDataState {}
 
 class EmptyFavoritesData extends FavoritesDataState {}
 
-class FavoritesData extends FavoritesDataState {
-  final List<Book> favoriteAuthor;
-  final Book? firstFiveStarBook;
+@Freezed()
+class FavoritesData extends FavoritesDataState with _$FavoritesData {
 
-  FavoritesData({
-    required this.favoriteAuthor,
-    required this.firstFiveStarBook,
-  });
+  const factory FavoritesData({
+    required List<Book> favoriteAuthor,
+    required Book? firstFiveStarBook,
+  }) = _FavoritesData;
 }
 
 class MiscStatsItem extends StatsItem {
@@ -165,24 +167,20 @@ sealed class MiscDataState {}
 
 class EmptyMiscData extends MiscDataState {}
 
-class MiscData extends MiscDataState {
-  final double averageBooksPerMonth;
-  final MostActiveMonth? mostActiveMonth;
-
-  MiscData({
-    required this.averageBooksPerMonth,
-    required this.mostActiveMonth,
-  });
+@Freezed()
+class MiscData extends MiscDataState with _$MiscData {
+  const factory MiscData({
+    required double averageBooksPerMonth,
+    required MostActiveMonth? mostActiveMonth,
+  }) = _MiscData;
 }
 
-class MostActiveMonth {
-  final String formattedMonthAndYear;
-  final List<Book> books;
-
-  MostActiveMonth({
-    required this.formattedMonthAndYear,
-    required this.books,
-  });
+@Freezed()
+class MostActiveMonth with _$MostActiveMonth {
+  const factory MostActiveMonth({
+    required DateTime month,
+    required List<Book> books,
+  }) = _MostActiveMonth;
 }
 
 class PagesPerMonthStatsItem extends StatsItem {

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -1,4 +1,5 @@
 import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'stats_item.freezed.dart';
@@ -177,10 +178,17 @@ class MiscData extends MiscDataState with _$MiscData {
 
 @Freezed()
 class MostActiveMonth with _$MostActiveMonth {
-  const factory MostActiveMonth({
+
+  MostActiveMonth._();
+
+  factory MostActiveMonth({
     required DateTime month,
     required List<Book> books,
   }) = _MostActiveMonth;
+
+  String get formattedMonth => DateFormat('MMM yyyy').format(month);
+
+  int get bookCount => books.length;
 }
 
 class PagesPerMonthStatsItem extends StatsItem {

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -122,3 +122,12 @@ class LabelData extends LabelDataState {
     required this.labelDistribution,
   });
 }
+
+class PagesPerMonthStatsItem extends StatsItem {
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 3, height: 1);
+
+  @override
+  String get titleKey => 'stats.pages-per-month.title';
+
+}

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -76,7 +76,6 @@ class ReadingTimeData extends ReadingTimeDataState {
 }
 
 class LanguageStatsItem extends StatsItem {
-
   final LanguageDataState dataState;
 
   LanguageStatsItem(this.dataState);
@@ -87,6 +86,7 @@ class LanguageStatsItem extends StatsItem {
   @override
   String get titleKey => 'stats.language.title';
 }
+
 sealed class LanguageDataState {}
 
 class EmptyLanguageData extends LanguageDataState {}
@@ -100,7 +100,6 @@ class LanguageData extends LanguageDataState {
 }
 
 class LabelStatsItem extends StatsItem {
-
   final LabelDataState dataState;
 
   LabelStatsItem(this.dataState);
@@ -111,6 +110,7 @@ class LabelStatsItem extends StatsItem {
   @override
   String get titleKey => 'stats.label.title';
 }
+
 sealed class LabelDataState {}
 
 class EmptyLabelData extends LabelDataState {}
@@ -124,7 +124,6 @@ class LabelData extends LabelDataState {
 }
 
 class FavoritesStatsItem extends StatsItem {
-
   final FavoritesDataState dataState;
 
   FavoritesStatsItem(this.dataState);
@@ -135,6 +134,7 @@ class FavoritesStatsItem extends StatsItem {
   @override
   String get titleKey => 'stats.favorites.title';
 }
+
 sealed class FavoritesDataState {}
 
 class EmptyFavoritesData extends FavoritesDataState {}
@@ -149,11 +149,46 @@ class FavoritesData extends FavoritesDataState {
   });
 }
 
+class MiscStatsItem extends StatsItem {
+  final MiscDataState dataState;
+
+  MiscStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
+
+  @override
+  String get titleKey => 'stats.misc.title';
+}
+
+sealed class MiscDataState {}
+
+class EmptyMiscData extends MiscDataState {}
+
+class MiscData extends MiscDataState {
+  final double averageBooksPerMonth;
+  final MostActiveMonth? mostActiveMonth;
+
+  MiscData({
+    required this.averageBooksPerMonth,
+    required this.mostActiveMonth,
+  });
+}
+
+class MostActiveMonth {
+  final String formattedMonthAndYear;
+  final List<Book> books;
+
+  MostActiveMonth({
+    required this.formattedMonthAndYear,
+    required this.books,
+  });
+}
+
 class PagesPerMonthStatsItem extends StatsItem {
   @override
   ItemDesktopSize get desktopSize => ItemDesktopSize(width: 3, height: 1);
 
   @override
   String get titleKey => 'stats.pages-per-month.title';
-
 }

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -1,17 +1,32 @@
 import 'package:dantex/src/data/book/entity/book.dart';
 
+class ItemDesktopSize {
+  final int width;
+  final int height;
+
+  ItemDesktopSize({
+    required this.width,
+    required this.height,
+  });
+}
+
 sealed class StatsItem {
-  String title();
+  String get titleKey;
+
+  /// The cross- and main axis size this item should occupy on desktop devices.
+  ItemDesktopSize get desktopSize;
 }
 
 class BooksAndPagesStatsItem extends StatsItem {
-
   final BooksAndPagesDataState dataState;
 
   BooksAndPagesStatsItem(this.dataState);
 
   @override
-  String title() => 'Books & Pages'; // TODO Translate
+  String get titleKey => 'stats.books-and-pages.title';
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 2, height: 1);
 }
 
 sealed class BooksAndPagesDataState {}
@@ -34,15 +49,17 @@ class BooksAndPagesData extends BooksAndPagesDataState {
   });
 }
 
-
 class ReadingTimeStatsItem extends StatsItem {
-
   final ReadingTimeDataState dataState;
 
   ReadingTimeStatsItem(this.dataState);
 
+  // TODO Translate
   @override
-  String title() => 'Reading Time'; // TODO Translate
+  String get titleKey => 'Reading Time';
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
 }
 
 sealed class ReadingTimeDataState {}
@@ -59,3 +76,50 @@ class ReadingTimeData extends ReadingTimeDataState {
   });
 }
 
+class LanguageStatsItem extends StatsItem {
+
+  final LanguageDataState dataState;
+
+  LanguageStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
+
+  @override
+  String get titleKey => 'Languages';
+}
+sealed class LanguageDataState {}
+
+class EmptyLanguageData extends LanguageDataState {}
+
+class LanguageData extends LanguageDataState {
+  final Map<String, int> languageDistribution;
+
+  LanguageData({
+    required this.languageDistribution,
+  });
+}
+
+class LabelStatsItem extends StatsItem {
+
+  final LabelDataState dataState;
+
+  LabelStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
+
+  @override
+  String get titleKey => 'Labels';
+}
+sealed class LabelDataState {}
+
+class EmptyLabelData extends LabelDataState {}
+
+class LabelData extends LabelDataState {
+  final Map<String, int> labelDistribution;
+
+  LabelData({
+    required this.labelDistribution,
+  });
+}

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -223,3 +223,29 @@ class BooksPerYearData extends BooksPerYearDataState {
     required this.booksPerYearDistribution,
   });
 }
+
+class BooksPerMonthStatsItem extends StatsItem {
+  final BooksPerMonthDataState dataState;
+
+  BooksPerMonthStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 2, height: 1);
+
+  @override
+  String get titleKey => 'stats.books-per-month.title';
+}
+
+
+sealed class BooksPerMonthDataState {}
+
+class EmptyBooksPerMonthData extends BooksPerMonthDataState {}
+
+class BooksPerMonthData extends BooksPerMonthDataState {
+  // Map contains Map<DateTime, Amount of books>
+  final Map<DateTime, int> booksPerMonthDistribution;
+
+  BooksPerMonthData({
+    required this.booksPerMonthDistribution,
+  });
+}

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -86,7 +86,7 @@ class LanguageStatsItem extends StatsItem {
   ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
 
   @override
-  String get titleKey => 'Languages';
+  String get titleKey => 'stats.language.title';
 }
 sealed class LanguageDataState {}
 
@@ -110,7 +110,7 @@ class LabelStatsItem extends StatsItem {
   ItemDesktopSize get desktopSize => ItemDesktopSize(width: 1, height: 1);
 
   @override
-  String get titleKey => 'Labels';
+  String get titleKey => 'stats.label.title';
 }
 sealed class LabelDataState {}
 

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -192,3 +192,28 @@ class PagesPerMonthStatsItem extends StatsItem {
   @override
   String get titleKey => 'stats.pages-per-month.title';
 }
+
+class BooksPerYearStatsItem extends StatsItem {
+  final BooksPerYearDataState dataState;
+
+  BooksPerYearStatsItem(this.dataState);
+
+  @override
+  ItemDesktopSize get desktopSize => ItemDesktopSize(width: 2, height: 1);
+
+  @override
+  String get titleKey => 'stats.books-per-year.title';
+}
+
+sealed class BooksPerYearDataState {}
+
+class EmptyBooksPerYearData extends BooksPerYearDataState {}
+
+class BooksPerYearData extends BooksPerYearDataState {
+  // Map contains Map<Year, Amount of books>
+  final Map<int, int> booksPerYearDistribution;
+
+  BooksPerYearData({
+    required this.booksPerYearDistribution,
+  });
+}

--- a/lib/src/data/stats/stats_item.dart
+++ b/lib/src/data/stats/stats_item.dart
@@ -1,0 +1,61 @@
+import 'package:dantex/src/data/book/entity/book.dart';
+
+sealed class StatsItem {
+  String title();
+}
+
+class BooksAndPagesStatsItem extends StatsItem {
+
+  final BooksAndPagesDataState dataState;
+
+  BooksAndPagesStatsItem(this.dataState);
+
+  @override
+  String title() => 'Books & Pages'; // TODO Translate
+}
+
+sealed class BooksAndPagesDataState {}
+
+class EmptyBooksAndPagesData extends BooksAndPagesDataState {}
+
+class BooksAndPagesData extends BooksAndPagesDataState {
+  final int booksWaiting;
+  final int booksReading;
+  final int booksRead;
+  final int pagesRead;
+  final int pagesWaiting;
+
+  BooksAndPagesData({
+    required this.booksWaiting,
+    required this.booksReading,
+    required this.booksRead,
+    required this.pagesRead,
+    required this.pagesWaiting,
+  });
+}
+
+
+class ReadingTimeStatsItem extends StatsItem {
+
+  final ReadingTimeDataState dataState;
+
+  ReadingTimeStatsItem(this.dataState);
+
+  @override
+  String title() => 'Reading Time'; // TODO Translate
+}
+
+sealed class ReadingTimeDataState {}
+
+class EmptyReadingTimeData extends ReadingTimeDataState {}
+
+class ReadingTimeData extends ReadingTimeDataState {
+  final Book fastestBook;
+  final Book slowestBook;
+
+  ReadingTimeData({
+    required this.slowestBook,
+    required this.fastestBook,
+  });
+}
+

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -8,11 +8,16 @@ import 'package:dantex/src/data/logging/firebase_log_output.dart';
 import 'package:dantex/src/data/recommendations/book_recommendation.dart';
 import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
+import 'package:dantex/src/data/stats/default_stats_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/data/timeline/timeline.dart';
 import 'package:dantex/src/providers/api.dart';
 import 'package:dantex/src/providers/repository.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:logger/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -29,8 +34,8 @@ IsbnScannerService isbnScannerService(IsbnScannerServiceRef ref) =>
     BarcodeIsbnScannerService();
 
 @riverpod
-Future<String> scanIsbn(ScanIsbnRef ref, BuildContext context) {
-  return ref.watch(isbnScannerServiceProvider).scanIsbn(context);
+Future<String> scanIsbn(ScanIsbnRef ref) {
+  return ref.watch(isbnScannerServiceProvider).scanIsbn();
 }
 
 @riverpod
@@ -88,4 +93,26 @@ Stream<RecommendationEvent> bookRecommendationEvents(
   BookRecommendationEventsRef ref,
 ) {
   return ref.watch(recommendationsProvider).events;
+}
+
+@riverpod
+StatsBuilder statsBuilder(StatsBuilderRef ref) {
+  return DefaultStatsBuilder(
+    ref.read(bookRepositoryProvider),
+    _provideStatsItemBuilders(),
+  );
+}
+
+List<StatsItemBuilder> _provideStatsItemBuilders() {
+  return [
+    BooksAndPagesStatsItemBuilder(),
+    // ReadingTimeStatsItemBuilder(),
+  ];
+}
+
+@riverpod
+Stream<List<StatsItem>> statsBuilderItems(
+  StatsBuilderItemsRef ref,
+) {
+  return ref.watch(statsBuilderProvider).buildStats();
 }

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -10,6 +10,7 @@ import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
 import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart';
@@ -113,6 +114,7 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     LanguageStatsItemBuilder(),
     LabelStatsItemBuilder(),
     PagesPerMonthStatsItemBuilder(),
+    FavoritesStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -10,6 +10,7 @@ import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
 import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/books_per_month_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_per_year_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
@@ -116,8 +117,9 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     LanguageStatsItemBuilder(),
     LabelStatsItemBuilder(),
     // PagesPerMonthStatsItemBuilder(),
-    // FavoritesStatsItemBuilder(),
+    BooksPerMonthStatsItemBuilder(),
     MiscStatsItemBuilder(DateTime.now()),
+    FavoritesStatsItemBuilder(),
     // BooksPerYearStatsItemBuilder(),
   ];
 }

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -10,6 +10,9 @@ import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
 import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
@@ -105,7 +108,9 @@ StatsBuilder statsBuilder(StatsBuilderRef ref) {
 List<StatsItemBuilder> _provideStatsItemBuilders() {
   return [
     BooksAndPagesStatsItemBuilder(),
-    // ReadingTimeStatsItemBuilder(),
+    ReadingTimeStatsItemBuilder(),
+    LanguageStatsItemBuilder(),
+    LabelStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -16,7 +16,6 @@ import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/misc_stats_item_builder.dart';
-import 'package:dantex/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_builder.dart';
@@ -120,7 +119,7 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     BooksPerMonthStatsItemBuilder(),
     MiscStatsItemBuilder(DateTime.now()),
     FavoritesStatsItemBuilder(),
-    // BooksPerYearStatsItemBuilder(),
+    BooksPerYearStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -112,9 +112,9 @@ StatsBuilder statsBuilder(StatsBuilderRef ref) {
 List<StatsItemBuilder> _provideStatsItemBuilders() {
   return [
     BooksAndPagesStatsItemBuilder(),
-    // ReadingTimeStatsItemBuilder(),
-    // LanguageStatsItemBuilder(),
-    // LabelStatsItemBuilder(),
+    ReadingTimeStatsItemBuilder(),
+    LanguageStatsItemBuilder(),
+    LabelStatsItemBuilder(),
     // PagesPerMonthStatsItemBuilder(),
     // FavoritesStatsItemBuilder(),
     // MiscStatsItemBuilder(),

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -117,7 +117,7 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     LabelStatsItemBuilder(),
     // PagesPerMonthStatsItemBuilder(),
     // FavoritesStatsItemBuilder(),
-    // MiscStatsItemBuilder(),
+    MiscStatsItemBuilder(DateTime.now()),
     // BooksPerYearStatsItemBuilder(),
   ];
 }

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -10,7 +10,6 @@ import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
 import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
-import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_builder.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -13,6 +13,7 @@ import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_bu
 import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/misc_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
@@ -115,6 +116,7 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     LabelStatsItemBuilder(),
     PagesPerMonthStatsItemBuilder(),
     FavoritesStatsItemBuilder(),
+    MiscStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -10,6 +10,7 @@ import 'package:dantex/src/data/recommendations/recommendations.dart';
 import 'package:dantex/src/data/search/search.dart';
 import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/books_per_year_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
@@ -111,12 +112,13 @@ StatsBuilder statsBuilder(StatsBuilderRef ref) {
 List<StatsItemBuilder> _provideStatsItemBuilders() {
   return [
     BooksAndPagesStatsItemBuilder(),
-    ReadingTimeStatsItemBuilder(),
-    LanguageStatsItemBuilder(),
-    LabelStatsItemBuilder(),
-    PagesPerMonthStatsItemBuilder(),
-    FavoritesStatsItemBuilder(),
-    MiscStatsItemBuilder(),
+    // ReadingTimeStatsItemBuilder(),
+    // LanguageStatsItemBuilder(),
+    // LabelStatsItemBuilder(),
+    // PagesPerMonthStatsItemBuilder(),
+    // FavoritesStatsItemBuilder(),
+    // MiscStatsItemBuilder(),
+    // BooksPerYearStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/providers/service.dart
+++ b/lib/src/providers/service.dart
@@ -12,6 +12,7 @@ import 'package:dantex/src/data/stats/default_stats_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/books_and_pages_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/label_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/language_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/item_builder/pages_per_month_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/reading_time_stats_item_builder.dart';
 import 'package:dantex/src/data/stats/item_builder/stats_item_builder.dart';
 import 'package:dantex/src/data/stats/stats_builder.dart';
@@ -111,6 +112,7 @@ List<StatsItemBuilder> _provideStatsItemBuilders() {
     ReadingTimeStatsItemBuilder(),
     LanguageStatsItemBuilder(),
     LabelStatsItemBuilder(),
+    PagesPerMonthStatsItemBuilder(),
   ];
 }
 

--- a/lib/src/ui/add/scan_book_page.dart
+++ b/lib/src/ui/add/scan_book_page.dart
@@ -11,7 +11,7 @@ class ScanBookPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      body: ref.watch(scanIsbnProvider(context)).maybeWhen(
+      body: ref.watch(scanIsbnProvider).maybeWhen(
         data: (query) {
           // Query might be invalid if user aborts scan process.
           if (query == _invalidIsbn) {

--- a/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
@@ -1,0 +1,18 @@
+
+
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:flutter/material.dart';
+
+class BooksAndPagesStatsItemWidget extends StatelessWidget {
+
+  final BooksAndPagesStatsItem _item;
+
+  const BooksAndPagesStatsItemWidget(this._item, {super.key,});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(_item.title());
+  }
+
+
+}

--- a/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 class BooksAndPagesStatsItemWidget extends StatelessWidget {
   final BooksAndPagesStatsItem _item;
 
+  final double _columnHeight = 300;
+
   const BooksAndPagesStatsItemWidget(
     this._item, {
     super.key,
@@ -17,19 +19,21 @@ class BooksAndPagesStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: _buildContent(),
+      content: _buildContent(context),
     );
   }
 
-  Widget _buildContent() {
+  Widget _buildContent(BuildContext context) {
     final BooksAndPagesDataState dataState = _item.dataState;
     return switch (dataState) {
-      EmptyBooksAndPagesData() => EmptyStatsView('stats.books-and-pages.empty'.tr()),
-      BooksAndPagesData() => _buildBody(dataState),
+      EmptyBooksAndPagesData() => EmptyStatsView(
+          'stats.books-and-pages.empty'.tr(),
+        ),
+      BooksAndPagesData() => _buildBody(context, dataState),
     };
   }
 
-  Widget _buildBody(BooksAndPagesData data) {
+  Widget _buildBody(BuildContext context, BooksAndPagesData data) {
     return Row(
       children: [
         Expanded(
@@ -37,8 +41,8 @@ class BooksAndPagesStatsItemWidget extends StatelessWidget {
             children: [
               Text('stats.books-and-pages.books'.tr()),
               SizedBox(
-                height: 300,
-                child: _buildBooksChart(data),
+                height: _columnHeight,
+                child: _buildBooksChart(context, data),
               ),
             ],
           ),
@@ -48,8 +52,8 @@ class BooksAndPagesStatsItemWidget extends StatelessWidget {
             children: [
               Text('stats.books-and-pages.pages'.tr()),
               SizedBox(
-                height: 300,
-                child: _buildPagesChart(data),
+                height: _columnHeight,
+                child: _buildPagesChart(context, data),
               ),
             ],
           ),
@@ -58,42 +62,56 @@ class BooksAndPagesStatsItemWidget extends StatelessWidget {
     );
   }
 
-  Widget _buildBooksChart(BooksAndPagesData data) {
+  Widget _buildBooksChart(BuildContext context, BooksAndPagesData data) {
     final Map<String, int> pieData = {
       'stats.books-and-pages.books-waiting': data.booksWaiting,
       'stats.books-and-pages.books-reading': data.booksReading,
       'stats.books-and-pages.books-read': data.booksRead,
     };
     return DantePieChart(
-      badgeBuilder: (String key, double size) => Card(
-        child: Container(
-          padding: const EdgeInsets.all(8),
-          child: Text(
-            key.tr(args: [pieData[key]!.toString()]),
-          ),
-        ),
+      badgeBuilder: (String key, double size) => _buildBadge(
+        context,
+        key,
+        pieData,
       ),
       pieData: pieData,
       titleBuilder: (String key, int value) => '',
     );
   }
 
-  Widget _buildPagesChart(BooksAndPagesData data) {
+  Widget _buildPagesChart(BuildContext context, BooksAndPagesData data) {
     final Map<String, int> pieData = {
       'stats.books-and-pages.pages-waiting': data.pagesWaiting,
       'stats.books-and-pages.pages-read': data.pagesRead,
     };
     return DantePieChart(
-      badgeBuilder: (String key, double size) => Card(
-        child: Container(
-          padding: const EdgeInsets.all(8),
-          child: Text(
-            key.tr(args: [pieData[key]!.toString()]),
-          ),
-        ),
+      badgeBuilder: (String key, double size) => _buildBadge(
+        context,
+        key,
+        pieData,
       ),
       pieData: pieData,
       titleBuilder: (String key, int value) => '',
+    );
+  }
+
+  Widget _buildBadge(
+    BuildContext context,
+    String key,
+    Map<String, int> pieData,
+  ) {
+    return Card(
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        child: Text(
+          key.tr(
+            args: [pieData[key]!.toString()],
+          ),
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onBackground,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/books_and_pages_stats_item_widget.dart
@@ -1,18 +1,99 @@
-
-
 import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/chart/dante_pie_chart.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
 class BooksAndPagesStatsItemWidget extends StatelessWidget {
-
   final BooksAndPagesStatsItem _item;
 
-  const BooksAndPagesStatsItemWidget(this._item, {super.key,});
+  const BooksAndPagesStatsItemWidget(
+    this._item, {
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Text(_item.title());
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: _buildContent(),
+    );
   }
 
+  Widget _buildContent() {
+    final BooksAndPagesDataState dataState = _item.dataState;
+    return switch (dataState) {
+      EmptyBooksAndPagesData() => EmptyStatsView('stats.books-and-pages.empty'.tr()),
+      BooksAndPagesData() => _buildBody(dataState),
+    };
+  }
 
+  Widget _buildBody(BooksAndPagesData data) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            children: [
+              Text('stats.books-and-pages.books'.tr()),
+              SizedBox(
+                height: 300,
+                child: _buildBooksChart(data),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Column(
+            children: [
+              Text('stats.books-and-pages.pages'.tr()),
+              SizedBox(
+                height: 300,
+                child: _buildPagesChart(data),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBooksChart(BooksAndPagesData data) {
+    final Map<String, int> pieData = {
+      'stats.books-and-pages.books-waiting': data.booksWaiting,
+      'stats.books-and-pages.books-reading': data.booksReading,
+      'stats.books-and-pages.books-read': data.booksRead,
+    };
+    return DantePieChart(
+      badgeBuilder: (String key, double size) => Card(
+        child: Container(
+          padding: const EdgeInsets.all(8),
+          child: Text(
+            key.tr(args: [pieData[key]!.toString()]),
+          ),
+        ),
+      ),
+      pieData: pieData,
+      titleBuilder: (String key, int value) => '',
+    );
+  }
+
+  Widget _buildPagesChart(BooksAndPagesData data) {
+    final Map<String, int> pieData = {
+      'stats.books-and-pages.pages-waiting': data.pagesWaiting,
+      'stats.books-and-pages.pages-read': data.pagesRead,
+    };
+    return DantePieChart(
+      badgeBuilder: (String key, double size) => Card(
+        child: Container(
+          padding: const EdgeInsets.all(8),
+          child: Text(
+            key.tr(args: [pieData[key]!.toString()]),
+          ),
+        ),
+      ),
+      pieData: pieData,
+      titleBuilder: (String key, int value) => '',
+    );
+  }
 }

--- a/lib/src/ui/stats/item/books_per_month_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/books_per_month_stats_item_widget.dart
@@ -1,0 +1,64 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/chart/dante_line_chart.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
+import 'package:dantex/src/util/point_2d.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class BooksPerMonthStatsItemWidget extends StatelessWidget
+    with MobileStatsMixin {
+  final BooksPerMonthStatsItem _item;
+
+  final bool isMobile;
+
+  const BooksPerMonthStatsItemWidget(
+    this._item, {
+    required this.isMobile,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: resolveTopLevelWidget(
+        child: _buildContent(context),
+        isMobile: isMobile,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final BooksPerMonthDataState state = _item.dataState;
+    return switch (state) {
+      EmptyBooksPerMonthData() => EmptyStatsView(
+          'stats.books-per-month.empty'.tr(),
+        ),
+      BooksPerMonthData() => _buildChart(context, state),
+    };
+  }
+
+  Widget _buildChart(BuildContext context, BooksPerMonthData state) {
+    return DanteLineChart(
+      _buildPoints(state.booksPerMonthDistribution),
+      xConverter: (double x) {
+        // TODO
+        return '';
+      },
+    );
+  }
+
+  List<Point2D> _buildPoints(Map<DateTime, int> booksPerMonthDistribution) {
+    return booksPerMonthDistribution.entries
+        .mapIndexed(
+          (index, e) => Point2D(
+            x: index.toDouble(),
+            y: e.value.toDouble(),
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/src/ui/stats/item/books_per_year_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/books_per_year_stats_item_widget.dart
@@ -4,18 +4,17 @@ import 'package:dantex/src/ui/stats/item/chart/dante_line_chart.dart';
 import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
 import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
-import 'package:dantex/src/util/extensions.dart';
 import 'package:dantex/src/util/point_2d.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
-class BooksPerMonthStatsItemWidget extends StatelessWidget
+class BooksPerYearStatsItemWidget extends StatelessWidget
     with MobileStatsMixin {
-  final BooksPerMonthStatsItem _item;
+  final BooksPerYearStatsItem _item;
 
   final bool isMobile;
 
-  const BooksPerMonthStatsItemWidget(
+  const BooksPerYearStatsItemWidget(
     this._item, {
     required this.isMobile,
     super.key,
@@ -33,28 +32,28 @@ class BooksPerMonthStatsItemWidget extends StatelessWidget
   }
 
   Widget _buildContent(BuildContext context) {
-    final BooksPerMonthDataState state = _item.dataState;
+    final BooksPerYearDataState state = _item.dataState;
     return switch (state) {
-      EmptyBooksPerMonthData() => EmptyStatsView(
-          'stats.books-per-month.empty'.tr(),
+      EmptyBooksPerYearData() => EmptyStatsView(
+          'stats.books-per-year.empty'.tr(),
         ),
-      BooksPerMonthData() => _buildChart(context, state),
+      BooksPerYearData() => _buildChart(context, state),
     };
   }
 
-  Widget _buildChart(BuildContext context, BooksPerMonthData state) {
+  Widget _buildChart(BuildContext context, BooksPerYearData state) {
     return DanteLineChart(
-      _buildPoints(state.booksPerMonthDistribution),
-      xConverter: (double x) => state.booksPerMonthDistribution.entries
+      _buildPoints(state.booksPerYearDistribution),
+      xConverter: (double x) => state.booksPerYearDistribution.entries
           .toList()[x.toInt()]
           .key
-          .formatWithMonthAndYearShort(),
+          .toString(),
       isMobile: isMobile,
     );
   }
 
-  List<Point2D> _buildPoints(Map<DateTime, int> booksPerMonthDistribution) {
-    return booksPerMonthDistribution.entries
+  List<Point2D> _buildPoints(Map<int, int> booksPerYearDistribution) {
+    return booksPerYearDistribution.entries
         .mapIndexed(
           (index, e) => Point2D(
             x: index.toDouble(),

--- a/lib/src/ui/stats/item/chart/dante_line_chart.dart
+++ b/lib/src/ui/stats/item/chart/dante_line_chart.dart
@@ -4,100 +4,35 @@ import 'package:flutter/material.dart';
 
 class DanteLineChart extends StatelessWidget {
   final List<Color> _gradientColors = [
-    Colors.cyan,
+    Colors.lightBlue,
     Colors.blue,
   ];
 
-  final Color _gridColor = Colors.red;
-
   final List<Point2D> _points;
   final String Function(double x) xConverter;
+  final bool isMobile;
 
   DanteLineChart(
     this._points, {
     required this.xConverter,
+    required this.isMobile,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return AspectRatio(
-      aspectRatio: 2, // TODO
+      aspectRatio: isMobile ? 3 : 2,
       child: LineChart(
-        _buildLineChartData(),
+        _buildLineChartData(context),
       ),
     );
   }
 
-  Widget _bottomTitleWidgets(double value, TitleMeta meta) {
-    const style = TextStyle(
-      fontWeight: FontWeight.bold,
-      fontSize: 16,
-    );
-    Widget text;
-    // TODO
-    switch (value.toInt()) {
-      case 2:
-        text = const Text('MAR', style: style);
-        break;
-      case 5:
-        text = const Text('JUN', style: style);
-        break;
-      case 8:
-        text = const Text('SEP', style: style);
-        break;
-      default:
-        text = const Text('', style: style);
-        break;
-    }
-
-    return SideTitleWidget(
-      axisSide: meta.axisSide,
-      child: text,
-    );
-  }
-
-  // TODO
-  Widget _leftTitleWidgets(double value, TitleMeta meta) {
-    const style = TextStyle(
-      fontWeight: FontWeight.bold,
-      fontSize: 15,
-    );
-    String text;
-    switch (value.toInt()) {
-      case 1:
-        text = '10K';
-        break;
-      case 3:
-        text = '30k';
-        break;
-      case 5:
-        text = '50k';
-        break;
-      default:
-        return Container();
-    }
-
-    return Text(text, style: style, textAlign: TextAlign.left);
-  }
-
-  LineChartData _buildLineChartData() {
+  LineChartData _buildLineChartData(BuildContext context) {
     return LineChartData(
-      gridData: FlGridData(
-        horizontalInterval: 1,
-        verticalInterval: 1,
-        getDrawingHorizontalLine: (value) {
-          return FlLine(
-            color: _gridColor,
-            strokeWidth: 1,
-          );
-        },
-        getDrawingVerticalLine: (value) {
-          return FlLine(
-            color: _gridColor,
-            strokeWidth: 1,
-          );
-        },
+      gridData: const FlGridData(
+        show: false,
       ),
       titlesData: FlTitlesData(
         bottomTitles: AxisTitles(
@@ -105,22 +40,30 @@ class DanteLineChart extends StatelessWidget {
             showTitles: true,
             reservedSize: 30,
             interval: 1,
-            getTitlesWidget: _bottomTitleWidgets,
+            getTitlesWidget: (double value, TitleMeta meta) =>
+                _bottomTitleWidgets(
+              context,
+              value,
+              meta,
+            ),
           ),
         ),
         leftTitles: AxisTitles(
           sideTitles: SideTitles(
             showTitles: true,
             interval: 1,
-            getTitlesWidget: _leftTitleWidgets,
+            getTitlesWidget: (double value, TitleMeta meta) => _buildLegendText(
+              context,
+              value.toString(),
+            ),
             reservedSize: 42,
           ),
         ),
+        rightTitles: const AxisTitles(),
+        topTitles: const AxisTitles(),
       ),
       borderData: FlBorderData(
-        show: true,
-        // TODO
-        border: Border.all(color: const Color(0xff37434d)),
+        show: false,
       ),
       minX: 0,
       // maxX: 11,
@@ -148,6 +91,32 @@ class DanteLineChart extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _bottomTitleWidgets(
+    BuildContext context,
+    double value,
+    TitleMeta meta,
+  ) {
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: _buildLegendText(
+        context,
+        xConverter(value),
+      ),
+    );
+  }
+
+  Widget _buildLegendText(BuildContext context, String text) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontWeight: FontWeight.bold,
+        fontSize: 16,
+        color: Theme.of(context).colorScheme.onSurface,
+      ),
+      textAlign: TextAlign.left,
     );
   }
 }

--- a/lib/src/ui/stats/item/chart/dante_line_chart.dart
+++ b/lib/src/ui/stats/item/chart/dante_line_chart.dart
@@ -1,0 +1,153 @@
+import 'package:dantex/src/util/point_2d.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class DanteLineChart extends StatelessWidget {
+  final List<Color> _gradientColors = [
+    Colors.cyan,
+    Colors.blue,
+  ];
+
+  final Color _gridColor = Colors.red;
+
+  final List<Point2D> _points;
+  final String Function(double x) xConverter;
+
+  DanteLineChart(
+    this._points, {
+    required this.xConverter,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 2, // TODO
+      child: LineChart(
+        _buildLineChartData(),
+      ),
+    );
+  }
+
+  Widget _bottomTitleWidgets(double value, TitleMeta meta) {
+    const style = TextStyle(
+      fontWeight: FontWeight.bold,
+      fontSize: 16,
+    );
+    Widget text;
+    // TODO
+    switch (value.toInt()) {
+      case 2:
+        text = const Text('MAR', style: style);
+        break;
+      case 5:
+        text = const Text('JUN', style: style);
+        break;
+      case 8:
+        text = const Text('SEP', style: style);
+        break;
+      default:
+        text = const Text('', style: style);
+        break;
+    }
+
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: text,
+    );
+  }
+
+  // TODO
+  Widget _leftTitleWidgets(double value, TitleMeta meta) {
+    const style = TextStyle(
+      fontWeight: FontWeight.bold,
+      fontSize: 15,
+    );
+    String text;
+    switch (value.toInt()) {
+      case 1:
+        text = '10K';
+        break;
+      case 3:
+        text = '30k';
+        break;
+      case 5:
+        text = '50k';
+        break;
+      default:
+        return Container();
+    }
+
+    return Text(text, style: style, textAlign: TextAlign.left);
+  }
+
+  LineChartData _buildLineChartData() {
+    return LineChartData(
+      gridData: FlGridData(
+        horizontalInterval: 1,
+        verticalInterval: 1,
+        getDrawingHorizontalLine: (value) {
+          return FlLine(
+            color: _gridColor,
+            strokeWidth: 1,
+          );
+        },
+        getDrawingVerticalLine: (value) {
+          return FlLine(
+            color: _gridColor,
+            strokeWidth: 1,
+          );
+        },
+      ),
+      titlesData: FlTitlesData(
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 30,
+            interval: 1,
+            getTitlesWidget: _bottomTitleWidgets,
+          ),
+        ),
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 1,
+            getTitlesWidget: _leftTitleWidgets,
+            reservedSize: 42,
+          ),
+        ),
+      ),
+      borderData: FlBorderData(
+        show: true,
+        // TODO
+        border: Border.all(color: const Color(0xff37434d)),
+      ),
+      minX: 0,
+      // maxX: 11,
+      minY: 0,
+      // maxY: 6,
+      lineBarsData: [
+        LineChartBarData(
+          spots: _points.map((e) => FlSpot(e.x, e.y)).toList(),
+          isCurved: true,
+          gradient: LinearGradient(
+            colors: _gradientColors,
+          ),
+          barWidth: 5,
+          isStrokeCapRound: true,
+          dotData: const FlDotData(
+            show: false,
+          ),
+          belowBarData: BarAreaData(
+            show: true,
+            gradient: LinearGradient(
+              colors: _gradientColors
+                  .map((color) => color.withOpacity(0.3))
+                  .toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/stats/item/chart/dante_pie_chart.dart
+++ b/lib/src/ui/stats/item/chart/dante_pie_chart.dart
@@ -84,7 +84,7 @@ class _DantePieChartState extends State<DantePieChart> {
           titleStyle: TextStyle(
             fontSize: fontSize,
             fontWeight: FontWeight.bold,
-            color: const Color(0xffffffff),
+            color: Colors.white12,
             shadows: shadows,
           ),
           badgeWidget: widget.badgeBuilder(

--- a/lib/src/ui/stats/item/chart/dante_pie_chart.dart
+++ b/lib/src/ui/stats/item/chart/dante_pie_chart.dart
@@ -34,6 +34,16 @@ class _DantePieChartState extends State<DantePieChart> {
         Theme.of(context).colorScheme.secondaryContainer,
       ];
 
+  List<Color> get _textColors => [
+        Theme.of(context).colorScheme.onPrimary,
+        Theme.of(context).colorScheme.onPrimaryContainer,
+        Theme.of(context).colorScheme.onTertiaryContainer,
+        Theme.of(context).colorScheme.onError,
+        Theme.of(context).colorScheme.onTertiary,
+        Theme.of(context).colorScheme.onSecondary,
+        Theme.of(context).colorScheme.onSecondaryContainer,
+      ];
+
   int _touchedIndex = -1;
 
   @override
@@ -84,7 +94,7 @@ class _DantePieChartState extends State<DantePieChart> {
           titleStyle: TextStyle(
             fontSize: fontSize,
             fontWeight: FontWeight.bold,
-            color: Colors.white12,
+            color: _textColors[index % length],
             shadows: shadows,
           ),
           badgeWidget: widget.badgeBuilder(

--- a/lib/src/ui/stats/item/chart/dante_pie_chart.dart
+++ b/lib/src/ui/stats/item/chart/dante_pie_chart.dart
@@ -1,0 +1,99 @@
+import 'package:collection/collection.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class DantePieChart extends StatefulWidget {
+  final Widget Function(
+    String key,
+    double size,
+  ) badgeBuilder;
+
+  final String Function(String key, int value) titleBuilder;
+
+  final Map<String, int> pieData;
+
+  const DantePieChart({
+    required this.badgeBuilder,
+    required this.pieData,
+    required this.titleBuilder,
+    super.key,
+  });
+
+  @override
+  State<DantePieChart> createState() => _DantePieChartState();
+}
+
+class _DantePieChartState extends State<DantePieChart> {
+  List<Color> get _colors => [
+        Theme.of(context).colorScheme.primary,
+        Theme.of(context).colorScheme.primaryContainer,
+        Theme.of(context).colorScheme.tertiaryContainer,
+        Theme.of(context).colorScheme.error,
+        Theme.of(context).colorScheme.tertiary,
+        Theme.of(context).colorScheme.secondary,
+        Theme.of(context).colorScheme.secondaryContainer,
+      ];
+
+  int _touchedIndex = -1;
+
+  @override
+  Widget build(BuildContext context) {
+    return PieChart(
+      PieChartData(
+        pieTouchData: PieTouchData(
+          touchCallback: (FlTouchEvent event, pieTouchResponse) {
+            setState(() {
+              if (!event.isInterestedForInteractions ||
+                  pieTouchResponse == null ||
+                  pieTouchResponse.touchedSection == null) {
+                _touchedIndex = -1;
+                return;
+              }
+              _touchedIndex =
+                  pieTouchResponse.touchedSection!.touchedSectionIndex;
+            });
+          },
+        ),
+        borderData: FlBorderData(
+          show: false,
+        ),
+        sectionsSpace: 0,
+        centerSpaceRadius: 0,
+        sections: _showingSections(widget.pieData),
+      ),
+    );
+  }
+
+  List<PieChartSectionData> _showingSections(
+    Map<String, int> data,
+  ) {
+    final int length = data.length;
+    return data.entries.mapIndexed(
+      (index, dataEntry) {
+        final isTouched = index == _touchedIndex;
+        final fontSize = isTouched ? 20.0 : 16.0;
+        final radius = isTouched ? 110.0 : 100.0;
+        final widgetSize = isTouched ? 55.0 : 40.0;
+        const shadows = [Shadow(blurRadius: 1)];
+
+        return PieChartSectionData(
+          color: _colors[index % length],
+          value: dataEntry.value.toDouble(),
+          title: widget.titleBuilder(dataEntry.key, dataEntry.value),
+          radius: radius,
+          titleStyle: TextStyle(
+            fontSize: fontSize,
+            fontWeight: FontWeight.bold,
+            color: const Color(0xffffffff),
+            shadows: shadows,
+          ),
+          badgeWidget: widget.badgeBuilder(
+            dataEntry.key,
+            widgetSize,
+          ),
+          badgePositionPercentageOffset: .98,
+        );
+      },
+    ).toList();
+  }
+}

--- a/lib/src/ui/stats/item/empty_stats_view.dart
+++ b/lib/src/ui/stats/item/empty_stats_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class EmptyStatsView extends StatelessWidget {
+  final String _text;
+
+  const EmptyStatsView(
+    this._text, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(_text),
+    );
+  }
+}

--- a/lib/src/ui/stats/item/empty_stats_view.dart
+++ b/lib/src/ui/stats/item/empty_stats_view.dart
@@ -11,7 +11,10 @@ class EmptyStatsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Text(_text),
+      child: Text(
+        _text,
+        style: TextStyle(color: Theme.of(context).colorScheme.onBackground),
+      ),
     );
   }
 }

--- a/lib/src/ui/stats/item/favorites_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/favorites_stats_item_widget.dart
@@ -1,0 +1,146 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/book/book_image.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class FavoritesStatsItemWidget extends StatelessWidget with MobileStatsMixin {
+
+  static const int _maxBooks = 3;
+
+  final FavoritesStatsItem _item;
+  final bool isMobile;
+
+  double get _imageSize => isMobile ? 48 : 72;
+
+  const FavoritesStatsItemWidget(
+    this._item, {
+    required this.isMobile,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: resolveTopLevelWidget(
+        child: _buildContent(context),
+        isMobile: isMobile,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final FavoritesDataState dataState = _item.dataState;
+    return switch (dataState) {
+      EmptyFavoritesData() => EmptyStatsView('stats.favorites.empty'.tr()),
+      FavoritesData() => _buildFavoritesContent(context, dataState),
+    };
+  }
+
+  Widget _buildFavoritesContent(
+    BuildContext context,
+    FavoritesData dataState,
+  ) {
+    return Row(
+      children: [
+        _buildFavoriteAuthor(
+          context,
+          dataState.favoriteAuthor,
+        ),
+        if (dataState.firstFiveStarBook != null) ...[
+          const VerticalDivider(
+            indent: 16,
+            endIndent: 16,
+            thickness: 1,
+          ),
+          _buildFirstFiveStarBook(
+            context,
+            dataState.firstFiveStarBook!,
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildFavoriteAuthor(
+    BuildContext context,
+    List<Book> favoriteAuthorBooks,
+  ) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'stats.favorites.favorite-author'.tr(),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.onBackground,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: favoriteAuthorBooks
+                .take(_maxBooks)
+                .mapIndexed(
+                  (index, e) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: BookImage(
+                      e.thumbnailAddress,
+                      size: _imageSize,
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            favoriteAuthorBooks.first.author,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onBackground,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFirstFiveStarBook(
+    BuildContext context,
+    Book book,
+  ) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'stats.favorites.first-five-star-book'.tr(),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.onBackground,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          BookImage(
+            book.thumbnailAddress,
+            size: _imageSize,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            book.title,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onBackground,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/ui/stats/item/label_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/label_stats_item_widget.dart
@@ -3,10 +3,10 @@ import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
-class ReadingTimeStatsItemWidget extends StatelessWidget {
-  final ReadingTimeStatsItem _item;
+class LabelStatsItemWidget extends StatelessWidget {
+  final LabelStatsItem _item;
 
-  const ReadingTimeStatsItemWidget(
+  const LabelStatsItemWidget(
     this._item, {
     super.key,
   });
@@ -15,7 +15,7 @@ class ReadingTimeStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: Text(_item.dataState.runtimeType.toString()),
+      content: Text('Labels'),
     );
   }
 }

--- a/lib/src/ui/stats/item/label_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/label_stats_item_widget.dart
@@ -1,6 +1,8 @@
 import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class LabelStatsItemWidget extends StatelessWidget {
@@ -15,7 +17,68 @@ class LabelStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: Text('Labels'),
+      content: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final LabelDataState state = _item.dataState;
+    return switch (state) {
+      EmptyLabelData() => Expanded(
+          child: EmptyStatsView(
+            'stats.label.empty'.tr(),
+          ),
+        ),
+      LabelData() => Flexible(child: _buildChart(context, state)),
+    };
+  }
+
+  Widget _buildChart(BuildContext context, LabelData state) {
+    return AspectRatio(
+      aspectRatio: 0.8,
+      child: RadarChart(
+        RadarChartData(
+          radarShape: RadarShape.polygon,
+          dataSets: [
+            RadarDataSet(
+              fillColor: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              borderColor: Theme.of(context).colorScheme.primary,
+              entryRadius: 1,
+              dataEntries: state.labelDistribution.values
+                  .map(
+                    (e) => RadarEntry(value: e.toDouble()),
+                  )
+                  .toList(),
+              borderWidth: 2,
+            )
+          ],
+          radarBackgroundColor: Colors.transparent,
+          borderData: FlBorderData(show: false),
+          radarBorderData: const BorderSide(color: Colors.transparent),
+          titlePositionPercentageOffset: 0.2,
+          titleTextStyle: TextStyle(
+            color: Theme.of(context).colorScheme.tertiary,
+            fontSize: 12,
+          ),
+          getTitle: (index, angle) {
+            final MapEntry<String, int> entry =
+                state.labelDistribution.entries.toList()[index];
+            return RadarChartTitle(
+              text: '${entry.key}\n(${entry.value})',
+            );
+          },
+          tickCount: 1,
+          ticksTextStyle: const TextStyle(
+            color: Colors.transparent,
+            fontSize: 10,
+          ),
+          tickBorderData: const BorderSide(color: Colors.transparent),
+          gridBorderData: BorderSide(
+            color: Theme.of(context).colorScheme.tertiary,
+            width: 1,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/ui/stats/item/label_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/label_stats_item_widget.dart
@@ -1,15 +1,18 @@
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
-class LabelStatsItemWidget extends StatelessWidget {
+class LabelStatsItemWidget extends StatelessWidget with MobileStatsMixin {
   final LabelStatsItem _item;
+  final bool isMobile;
 
   const LabelStatsItemWidget(
     this._item, {
+    required this.isMobile,
     super.key,
   });
 
@@ -17,19 +20,21 @@ class LabelStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: _buildContent(context),
+      content: resolveTopLevelWidget(
+        child: _buildContent(context),
+        isMobile: isMobile,
+        mobileHeight: 280,
+      ),
     );
   }
 
   Widget _buildContent(BuildContext context) {
     final LabelDataState state = _item.dataState;
     return switch (state) {
-      EmptyLabelData() => Expanded(
-          child: EmptyStatsView(
-            'stats.label.empty'.tr(),
-          ),
+      EmptyLabelData() => EmptyStatsView(
+          'stats.label.empty'.tr(),
         ),
-      LabelData() => Flexible(child: _buildChart(context, state)),
+      LabelData() => _buildChart(context, state),
     };
   }
 
@@ -50,7 +55,7 @@ class LabelStatsItemWidget extends StatelessWidget {
                   )
                   .toList(),
               borderWidth: 2,
-            )
+            ),
           ],
           radarBackgroundColor: Colors.transparent,
           borderData: FlBorderData(show: false),
@@ -75,7 +80,6 @@ class LabelStatsItemWidget extends StatelessWidget {
           tickBorderData: const BorderSide(color: Colors.transparent),
           gridBorderData: BorderSide(
             color: Theme.of(context).colorScheme.tertiary,
-            width: 1,
           ),
         ),
       ),

--- a/lib/src/ui/stats/item/language_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/language_stats_item_widget.dart
@@ -26,8 +26,7 @@ class LanguageStatsItemWidget extends StatelessWidget {
   Widget _buildContent() {
     final LanguageDataState state = _item.dataState;
     return switch (state) {
-      // TODO Translate
-      EmptyLanguageData() => EmptyStatsView('No data for languages'),
+      EmptyLanguageData() => EmptyStatsView('stats.language.empty'.tr()),
       LanguageData() => _buildChart(state),
     };
   }

--- a/lib/src/ui/stats/item/language_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/language_stats_item_widget.dart
@@ -25,7 +25,7 @@ class LanguageStatsItemWidget extends StatelessWidget with MobileStatsMixin {
       content: resolveTopLevelWidget(
         isMobile: isMobile,
         child: _buildContent(),
-        mobileHeight: 240
+        mobileHeight: 240,
       ),
     );
   }

--- a/lib/src/ui/stats/item/language_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/language_stats_item_widget.dart
@@ -1,0 +1,105 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/chart/dante_pie_chart.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class LanguageStatsItemWidget extends StatelessWidget {
+  final LanguageStatsItem _item;
+
+  const LanguageStatsItemWidget(
+    this._item, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: Expanded(child: _buildContent()),
+    );
+  }
+
+  Widget _buildContent() {
+    final LanguageDataState state = _item.dataState;
+    return switch (state) {
+      // TODO Translate
+      EmptyLanguageData() => EmptyStatsView('No data for languages'),
+      LanguageData() => _buildChart(state),
+    };
+  }
+
+  Widget _buildChart(LanguageData data) {
+    return DantePieChart(
+      pieData: data.languageDistribution,
+      badgeBuilder: _Badge.new,
+      titleBuilder: (_, value) => value.toString(),
+    );
+  }
+
+}
+
+class _Badge extends StatelessWidget {
+  final String _languageNotAvailable = 'na';
+  final String language;
+  final double size;
+
+  const _Badge(
+    this.language,
+    this.size,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: PieChart.defaultDuration,
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: Colors.grey,
+          width: 1,
+        ),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withOpacity(.5),
+            offset: const Offset(3, 3),
+            blurRadius: 3,
+          ),
+        ],
+      ),
+      padding: EdgeInsets.all(size * .15),
+      child: Center(
+        child: _buildFlag(),
+      ),
+    );
+  }
+
+  Widget _buildFlag() {
+    if (language.toLowerCase() == _languageNotAvailable) {
+      return Text('NA');
+    }
+
+    return CachedNetworkImage(
+      imageUrl: _buildUrl(language),
+    );
+  }
+
+  String _buildUrl(String language) {
+    return 'https://flagsapi.com/${_normalizeLanguage(language)}/flat/64.png';
+  }
+
+  String _normalizeLanguage(String language) {
+
+    if (language.toLowerCase() == 'en') {
+      return 'GB';
+    }
+
+    return language.toUpperCase();
+  }
+}

--- a/lib/src/ui/stats/item/language_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/language_stats_item_widget.dart
@@ -3,15 +3,18 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/chart/dante_pie_chart.dart';
 import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
-class LanguageStatsItemWidget extends StatelessWidget {
+class LanguageStatsItemWidget extends StatelessWidget with MobileStatsMixin {
   final LanguageStatsItem _item;
+  final bool isMobile;
 
   const LanguageStatsItemWidget(
     this._item, {
+    required this.isMobile,
     super.key,
   });
 
@@ -19,7 +22,11 @@ class LanguageStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: Expanded(child: _buildContent()),
+      content: resolveTopLevelWidget(
+        isMobile: isMobile,
+        child: _buildContent(),
+        mobileHeight: 240
+      ),
     );
   }
 
@@ -38,7 +45,6 @@ class LanguageStatsItemWidget extends StatelessWidget {
       titleBuilder: (_, value) => value.toString(),
     );
   }
-
 }
 
 class _Badge extends StatelessWidget {
@@ -62,7 +68,6 @@ class _Badge extends StatelessWidget {
         shape: BoxShape.circle,
         border: Border.all(
           color: Colors.grey,
-          width: 1,
         ),
         boxShadow: <BoxShadow>[
           BoxShadow(
@@ -81,7 +86,7 @@ class _Badge extends StatelessWidget {
 
   Widget _buildFlag() {
     if (language.toLowerCase() == _languageNotAvailable) {
-      return Text('NA');
+      return Text('stats.label.na'.tr());
     }
 
     return CachedNetworkImage(
@@ -94,7 +99,6 @@ class _Badge extends StatelessWidget {
   }
 
   String _normalizeLanguage(String language) {
-
     if (language.toLowerCase() == 'en') {
       return 'GB';
     }

--- a/lib/src/ui/stats/item/misc_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/misc_stats_item_widget.dart
@@ -1,0 +1,40 @@
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class MiscStatsItemWidget extends StatelessWidget with MobileStatsMixin {
+  final MiscStatsItem _item;
+  final bool isMobile;
+
+  const MiscStatsItemWidget(
+    this._item, {
+    required this.isMobile,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: resolveTopLevelWidget(
+        child: _buildContent(context),
+        isMobile: isMobile,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final MiscDataState dataState = _item.dataState;
+    return switch (dataState) {
+      EmptyMiscData() => EmptyStatsView('stats.misc.empty'.tr()),
+      MiscData() => _buildMiscContent(context, dataState),
+    };
+  }
+
+  Widget _buildMiscContent(BuildContext context, MiscData dataState) {
+    return Text('av');
+  }
+}

--- a/lib/src/ui/stats/item/misc_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/misc_stats_item_widget.dart
@@ -35,6 +35,63 @@ class MiscStatsItemWidget extends StatelessWidget with MobileStatsMixin {
   }
 
   Widget _buildMiscContent(BuildContext context, MiscData dataState) {
-    return Text('av');
+    return Row(
+      children: [
+        _buildMiscWidget(
+          context,
+          content: dataState.averageBooksPerMonth.toStringAsFixed(2),
+          description: 'stats.misc.average-books.description'.tr(),
+        ),
+        _buildMostActiveMonthWidget(context, dataState),
+      ],
+    );
+  }
+
+  Widget _buildMostActiveMonthWidget(BuildContext context, MiscData dataState) {
+    if (dataState.mostActiveMonth == null) {
+      return const SizedBox.shrink();
+    }
+
+    final String content =
+        dataState.mostActiveMonth?.bookCount.toString() ?? '---';
+
+    final String description = 'stats.misc.most-read-month.description'.tr(
+      args: [dataState.mostActiveMonth!.formattedMonth],
+    );
+
+    return _buildMiscWidget(
+      context,
+      content: content,
+      description: description,
+    );
+  }
+
+  Widget _buildMiscWidget(
+    BuildContext context, {
+    required String content,
+    required String description,
+  }) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            content,
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onBackground,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onBackground,
+                ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/ui/stats/item/pages_per_month_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/pages_per_month_stats_item_widget.dart
@@ -1,0 +1,27 @@
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class PagesPerMonthStatsItemWidget extends StatelessWidget {
+  final PagesPerMonthStatsItem _item;
+
+  const PagesPerMonthStatsItemWidget(
+    this._item, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StatsItemCard(
+      title: _item.titleKey.tr(),
+      content: _buildContent(),
+    );
+  }
+
+  Widget _buildContent() {
+    return const Center(
+      child: Text('Content goes here'),
+    );
+  }
+}

--- a/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
@@ -1,4 +1,7 @@
+import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/book/book_image.dart';
+import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -15,7 +18,89 @@ class ReadingTimeStatsItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return StatsItemCard(
       title: _item.titleKey.tr(),
-      content: Text(_item.dataState.runtimeType.toString()),
+      content: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final ReadingTimeDataState dataState = _item.dataState;
+    return switch (dataState) {
+      EmptyReadingTimeData() => Expanded(
+          child: EmptyStatsView('stats.reading-time.empty'.tr()),
+        ),
+      ReadingTimeData() => _buildReadingTimeContent(context, dataState),
+    };
+  }
+
+  Widget _buildReadingTimeContent(
+    BuildContext context,
+    ReadingTimeData dataState,
+  ) {
+    return Expanded(
+      child: Row(
+        children: [
+          _buildReadingTimeWidget(
+            context,
+            'stats.reading-time.fastest-book'.tr(),
+            dataState.fastestBook,
+          ),
+          const VerticalDivider(
+            indent: 16,
+            endIndent: 16,
+            thickness: 1,
+          ),
+          _buildReadingTimeWidget(
+            context,
+            'stats.reading-time.slowest-book'.tr(),
+            dataState.slowestBook,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReadingTimeWidget(
+    BuildContext context,
+    String label,
+    Book book,
+  ) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.onBackground,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          BookImage(book.thumbnailAddress, size: 48),
+          const SizedBox(height: 16),
+          Text(
+            book.title,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.onBackground,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _durationInDays(book),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onBackground,
+                ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _durationInDays(Book book) {
+    return 'stats.reading-time.days'.tr(
+      args: [book.endDate!.difference(book.startDate!).inDays.toString()],
     );
   }
 }

--- a/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
@@ -1,0 +1,17 @@
+
+
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:flutter/material.dart';
+
+class ReadingTimeStatsItemWidget extends StatelessWidget {
+
+  final ReadingTimeStatsItem _item;
+
+  const ReadingTimeStatsItemWidget(this._item, {super.key,});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(_item.title());
+  }
+
+}

--- a/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
+++ b/lib/src/ui/stats/item/reading_time_stats_item_widget.dart
@@ -3,14 +3,17 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/book/book_image.dart';
 import 'package:dantex/src/ui/stats/item/empty_stats_view.dart';
 import 'package:dantex/src/ui/stats/item/stats_item_card.dart';
+import 'package:dantex/src/ui/stats/item/util/mobile_stats_mixin.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
-class ReadingTimeStatsItemWidget extends StatelessWidget {
+class ReadingTimeStatsItemWidget extends StatelessWidget with MobileStatsMixin {
   final ReadingTimeStatsItem _item;
+  final bool isMobile;
 
   const ReadingTimeStatsItemWidget(
     this._item, {
+    required this.isMobile,
     super.key,
   });
 
@@ -25,7 +28,8 @@ class ReadingTimeStatsItemWidget extends StatelessWidget {
   Widget _buildContent(BuildContext context) {
     final ReadingTimeDataState dataState = _item.dataState;
     return switch (dataState) {
-      EmptyReadingTimeData() => Expanded(
+      EmptyReadingTimeData() => resolveTopLevelWidget(
+          isMobile: isMobile,
           child: EmptyStatsView('stats.reading-time.empty'.tr()),
         ),
       ReadingTimeData() => _buildReadingTimeContent(context, dataState),
@@ -36,7 +40,8 @@ class ReadingTimeStatsItemWidget extends StatelessWidget {
     BuildContext context,
     ReadingTimeData dataState,
   ) {
-    return Expanded(
+    return resolveTopLevelWidget(
+      isMobile: isMobile,
       child: Row(
         children: [
           _buildReadingTimeWidget(

--- a/lib/src/ui/stats/item/stats_item_card.dart
+++ b/lib/src/ui/stats/item/stats_item_card.dart
@@ -1,0 +1,29 @@
+import 'package:dantex/src/ui/core/dante_components.dart';
+import 'package:flutter/material.dart';
+
+class StatsItemCard extends StatelessWidget {
+  final String title;
+  final Widget content;
+
+  const StatsItemCard({
+    super.key,
+    required this.title,
+    required this.content,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DanteOutlinedCard(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Text(title),
+            const SizedBox(height: 16),
+            content,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/stats/item/stats_item_card.dart
+++ b/lib/src/ui/stats/item/stats_item_card.dart
@@ -6,9 +6,9 @@ class StatsItemCard extends StatelessWidget {
   final Widget content;
 
   const StatsItemCard({
-    super.key,
     required this.title,
     required this.content,
+    super.key,
   });
 
   @override
@@ -18,7 +18,12 @@ class StatsItemCard extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: [
-            Text(title),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onBackground,
+                  ),
+            ),
             const SizedBox(height: 16),
             content,
           ],

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -2,6 +2,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/language_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/misc_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/pages_per_month_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/reading_time_stats_item_widget.dart';
 import 'package:flutter/material.dart';
@@ -25,10 +26,9 @@ class StatsItemWidgetResolver {
           isMobile: isMobile,
         ),
       PagesPerMonthStatsItem() => PagesPerMonthStatsItemWidget(item),
+      MiscStatsItem() => MiscStatsItemWidget(item, isMobile: isMobile,),
       // TODO: Handle this case.
       FavoritesStatsItem() => Container(),
-      // TODO: Handle this case.
-      MiscStatsItem() => Container(),
       // TODO: Handle this case.
       BooksPerYearStatsItem() => Container(),
     };

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
@@ -9,17 +6,24 @@ import 'package:dantex/src/ui/stats/item/pages_per_month_stats_item_widget.dart'
 import 'package:dantex/src/ui/stats/item/reading_time_stats_item_widget.dart';
 import 'package:flutter/material.dart';
 
-
 class StatsItemWidgetResolver {
-
   StatsItemWidgetResolver._();
 
-  static Widget resolveItem(StatsItem item) {
+  static Widget resolveItem(StatsItem item, {bool isMobile = false}) {
     return switch (item) {
       BooksAndPagesStatsItem() => BooksAndPagesStatsItemWidget(item),
-      ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(item),
-      LanguageStatsItem() => LanguageStatsItemWidget(item),
-      LabelStatsItem() => LabelStatsItemWidget(item),
+      ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
+      LanguageStatsItem() => LanguageStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
+      LabelStatsItem() => LabelStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
       PagesPerMonthStatsItem() => PagesPerMonthStatsItemWidget(item),
       // TODO: Handle this case.
       FavoritesStatsItem() => Container(),

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -1,5 +1,7 @@
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/books_per_month_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/favorites_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/language_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/misc_stats_item_widget.dart';
@@ -30,10 +32,16 @@ class StatsItemWidgetResolver {
           item,
           isMobile: isMobile,
         ),
-      // TODO: Handle this case.
-      FavoritesStatsItem() => Container(),
+      FavoritesStatsItem() => FavoritesStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
       // TODO: Handle this case.
       BooksPerYearStatsItem() => Container(),
+      BooksPerMonthStatsItem() => BooksPerMonthStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
     };
   }
 }

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -21,6 +21,12 @@ class StatsItemWidgetResolver {
       LanguageStatsItem() => LanguageStatsItemWidget(item),
       LabelStatsItem() => LabelStatsItemWidget(item),
       PagesPerMonthStatsItem() => PagesPerMonthStatsItemWidget(item),
+      // TODO: Handle this case.
+      FavoritesStatsItem() => Container(),
+      // TODO: Handle this case.
+      MiscStatsItem() => Container(),
+      // TODO: Handle this case.
+      BooksPerYearStatsItem() => Container(),
     };
   }
 }

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -26,7 +26,10 @@ class StatsItemWidgetResolver {
           isMobile: isMobile,
         ),
       PagesPerMonthStatsItem() => PagesPerMonthStatsItemWidget(item),
-      MiscStatsItem() => MiscStatsItemWidget(item, isMobile: isMobile,),
+      MiscStatsItem() => MiscStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
       // TODO: Handle this case.
       FavoritesStatsItem() => Container(),
       // TODO: Handle this case.

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -1,0 +1,19 @@
+
+
+
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/reading_time_stats_item_widget.dart';
+import 'package:flutter/material.dart';
+
+class StatsItemWidgetResolver {
+
+  StatsItemWidgetResolver._();
+
+  static Widget resolveItem(StatsItem item) {
+    return switch (item) {
+      BooksAndPagesStatsItem() => BooksAndPagesStatsItemWidget(item),
+      ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(item),
+    };
+  }
+}

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -1,6 +1,7 @@
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/books_per_month_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/books_per_year_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/favorites_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/language_stats_item_widget.dart';
@@ -12,7 +13,10 @@ import 'package:flutter/material.dart';
 class StatsItemWidgetResolver {
   StatsItemWidgetResolver._();
 
-  static Widget resolveItem(StatsItem item, {bool isMobile = false}) {
+  static Widget resolveItem(
+    StatsItem item, {
+    bool isMobile = false,
+  }) {
     return switch (item) {
       BooksAndPagesStatsItem() => BooksAndPagesStatsItemWidget(item),
       ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(
@@ -36,8 +40,10 @@ class StatsItemWidgetResolver {
           item,
           isMobile: isMobile,
         ),
-      // TODO: Handle this case.
-      BooksPerYearStatsItem() => Container(),
+      BooksPerYearStatsItem() => BooksPerYearStatsItemWidget(
+          item,
+          isMobile: isMobile,
+        ),
       BooksPerMonthStatsItem() => BooksPerMonthStatsItemWidget(
           item,
           isMobile: isMobile,

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -3,8 +3,11 @@
 
 import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/language_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/reading_time_stats_item_widget.dart';
 import 'package:flutter/material.dart';
+
 
 class StatsItemWidgetResolver {
 
@@ -14,6 +17,8 @@ class StatsItemWidgetResolver {
     return switch (item) {
       BooksAndPagesStatsItem() => BooksAndPagesStatsItemWidget(item),
       ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(item),
+      LanguageStatsItem() => LanguageStatsItemWidget(item),
+      LabelStatsItem() => LabelStatsItemWidget(item),
     };
   }
 }

--- a/lib/src/ui/stats/item/stats_item_widget_resolver.dart
+++ b/lib/src/ui/stats/item/stats_item_widget_resolver.dart
@@ -5,6 +5,7 @@ import 'package:dantex/src/data/stats/stats_item.dart';
 import 'package:dantex/src/ui/stats/item/books_and_pages_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/label_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/language_stats_item_widget.dart';
+import 'package:dantex/src/ui/stats/item/pages_per_month_stats_item_widget.dart';
 import 'package:dantex/src/ui/stats/item/reading_time_stats_item_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -19,6 +20,7 @@ class StatsItemWidgetResolver {
       ReadingTimeStatsItem() => ReadingTimeStatsItemWidget(item),
       LanguageStatsItem() => LanguageStatsItemWidget(item),
       LabelStatsItem() => LabelStatsItemWidget(item),
+      PagesPerMonthStatsItem() => PagesPerMonthStatsItemWidget(item),
     };
   }
 }

--- a/lib/src/ui/stats/item/util/mobile_stats_mixin.dart
+++ b/lib/src/ui/stats/item/util/mobile_stats_mixin.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+
+mixin MobileStatsMixin {
+  Widget resolveTopLevelWidget({
+    required Widget child,
+    required bool isMobile,
+    double mobileHeight = 200,
+  }) {
+    return isMobile
+        ? SizedBox(
+            height: mobileHeight,
+            child: child,
+          )
+        : Expanded(
+            child: child,
+          );
+  }
+}

--- a/lib/src/ui/stats/stats_page.dart
+++ b/lib/src/ui/stats/stats_page.dart
@@ -1,14 +1,56 @@
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:dantex/src/providers/service.dart';
+import 'package:dantex/src/ui/core/dante_loading_indicator.dart';
+import 'package:dantex/src/ui/core/generic_error_widget.dart';
+import 'package:dantex/src/ui/core/themed_app_bar.dart';
+import 'package:dantex/src/ui/stats/item/stats_item_widget_resolver.dart';
+import 'package:dantex/src/util/layout_utils.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class StatsPage extends StatelessWidget {
+class StatsPage extends ConsumerWidget {
   const StatsPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Material(
-      child: Center(
-        child: Text('TODO Implement Statistics'),
-      ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final DeviceFormFactor formFactor = getDeviceFormFactor(constraints);
+        return Scaffold(
+          appBar: formFactor == DeviceFormFactor.desktop
+              ? null
+              : ThemedAppBar(
+                  title: Text('navigation.stats'.tr()),
+                ),
+          body: _buildBody(
+            ref,
+            context,
+            formFactor,
+          ),
+        );
+      },
     );
+  }
+
+  Widget _buildBody(
+    WidgetRef ref,
+    BuildContext context,
+    DeviceFormFactor formFactor,
+  ) {
+    return ref.watch(statsBuilderItemsProvider).when(
+          data: (List<StatsItem> items) {
+            // TODO Use form Factor for building a gridview?
+            return ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) =>
+                  StatsItemWidgetResolver.resolveItem(
+                items[index],
+              ),
+            );
+          },
+          error: (error, stackTrace) => GenericErrorWidget(error),
+          loading: () => const DanteLoadingIndicator(),
+        );
   }
 }

--- a/lib/src/ui/stats/stats_page.dart
+++ b/lib/src/ui/stats/stats_page.dart
@@ -8,6 +8,7 @@ import 'package:dantex/src/util/layout_utils.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 class StatsPage extends ConsumerWidget {
   const StatsPage({super.key});
@@ -40,17 +41,52 @@ class StatsPage extends ConsumerWidget {
   ) {
     return ref.watch(statsBuilderItemsProvider).when(
           data: (List<StatsItem> items) {
-            // TODO Use form Factor for building a gridview?
-            return ListView.builder(
-              itemCount: items.length,
-              itemBuilder: (context, index) =>
-                  StatsItemWidgetResolver.resolveItem(
-                items[index],
-              ),
-            );
+            return switch (formFactor) {
+              DeviceFormFactor.desktop => _buildDesktopView(items),
+              DeviceFormFactor.tablet => _buildMobileView(items),
+              DeviceFormFactor.phone => _buildMobileView(items),
+            };
           },
           error: (error, stackTrace) => GenericErrorWidget(error),
           loading: () => const DanteLoadingIndicator(),
         );
+  }
+
+  Widget _buildDesktopView(List<StatsItem> items) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: GridView.custom(
+        gridDelegate: SliverQuiltedGridDelegate(
+          crossAxisCount: 4,
+          mainAxisSpacing: 4,
+          crossAxisSpacing: 4,
+          repeatPattern: QuiltedGridRepeatPattern.inverted,
+          pattern: items
+              .map(
+                (e) => QuiltedGridTile(
+                  e.desktopSize.height,
+                  e.desktopSize.width,
+                ),
+              )
+              .toList(),
+        ),
+        childrenDelegate: SliverChildBuilderDelegate(
+          childCount: items.length,
+          (context, index) => StatsItemWidgetResolver.resolveItem(
+            items[index],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMobileView(List<StatsItem> items) {
+    return ListView.builder(
+      physics: const BouncingScrollPhysics(),
+      itemCount: items.length,
+      itemBuilder: (context, index) => StatsItemWidgetResolver.resolveItem(
+        items[index],
+      ),
+    );
   }
 }

--- a/lib/src/ui/stats/stats_page.dart
+++ b/lib/src/ui/stats/stats_page.dart
@@ -81,13 +81,15 @@ class StatsPage extends ConsumerWidget {
   }
 
   Widget _buildMobileView(List<StatsItem> items) {
-    return ListView.builder(
+    return ListView.separated(
       physics: const BouncingScrollPhysics(),
       padding: const EdgeInsets.all(16),
       itemCount: items.length,
       itemBuilder: (context, index) => StatsItemWidgetResolver.resolveItem(
         items[index],
+        isMobile: true,
       ),
+      separatorBuilder: (context, index) => const SizedBox(height: 8),
     );
   }
 }

--- a/lib/src/ui/stats/stats_page.dart
+++ b/lib/src/ui/stats/stats_page.dart
@@ -83,6 +83,7 @@ class StatsPage extends ConsumerWidget {
   Widget _buildMobileView(List<StatsItem> items) {
     return ListView.builder(
       physics: const BouncingScrollPhysics(),
+      padding: const EdgeInsets.all(16),
       itemCount: items.length,
       itemBuilder: (context, index) => StatsItemWidgetResolver.resolveItem(
         items[index],

--- a/lib/src/util/extensions.dart
+++ b/lib/src/util/extensions.dart
@@ -16,10 +16,14 @@ extension HexColor on String {
 }
 
 final DateFormat _dfMonth = DateFormat('MMMM yyyy');
+final DateFormat _dfMonthShort = DateFormat('MMM yy');
 
 extension DateTimeX on DateTime {
   String formatWithMonthAndYear() {
     return _dfMonth.format(this);
+  }
+  String formatWithMonthAndYearShort() {
+    return _dfMonthShort.format(this);
   }
 }
 

--- a/lib/src/util/extensions.dart
+++ b/lib/src/util/extensions.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
 import 'package:easy_localization/easy_localization.dart';
 
 extension HexColor on String {
@@ -27,5 +28,11 @@ extension BookListX on Iterable<Book> {
     return sorted(
       (a, b) => a.startDate?.compareTo(b.startDate ?? DateTime.now()) ?? -1,
     );
+  }
+
+  List<Book> filterReadBooks() {
+    return where(
+      (book) => book.state == BookState.read,
+    ).toList();
   }
 }

--- a/lib/src/util/extensions.dart
+++ b/lib/src/util/extensions.dart
@@ -32,7 +32,7 @@ extension BookListX on Iterable<Book> {
 
   List<Book> filterReadBooks() {
     return where(
-      (book) => book.state == BookState.read,
+      (book) => book.state == BookState.read && book.endDate != null,
     ).toList();
   }
 }

--- a/lib/src/util/extensions.dart
+++ b/lib/src/util/extensions.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
 import 'package:easy_localization/easy_localization.dart';
 
 extension HexColor on String {
@@ -17,5 +19,13 @@ final DateFormat _dfMonth = DateFormat('MMMM yyyy');
 extension DateTimeX on DateTime {
   String formatWithMonthAndYear() {
     return _dfMonth.format(this);
+  }
+}
+
+extension BookListX on Iterable<Book> {
+  List<Book> sortedByStartDate() {
+    return sorted(
+      (a, b) => a.startDate?.compareTo(b.startDate ?? DateTime.now()) ?? -1,
+    );
   }
 }

--- a/lib/src/util/point_2d.dart
+++ b/lib/src/util/point_2d.dart
@@ -1,0 +1,9 @@
+class Point2D {
+  final double x;
+  final double y;
+
+  Point2D({
+    required this.x,
+    required this.y,
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -313,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.17"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   expandable:
     dependency: "direct main"
     description:
@@ -497,6 +505,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "5a74434cc83bf64346efb562f1a06eefaf1bcb530dc3d96a104f631a1eff8d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.65.0"
   flex_color_picker:
     dependency: "direct main"
     description:
@@ -579,6 +595,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.9"
+  flutter_staggered_grid_view:
+    dependency: "direct main"
+    description:
+      name: flutter_staggered_grid_view
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   googleapis: ^11.4.0
   google_sign_in: ^6.1.6
   extension_google_sign_in_as_googleapis_auth: ^2.0.11
+  fl_chart: ^0.65.0
+  flutter_staggered_grid_view: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/test/data/stats/favorites_stats_item_builder_test.dart
+++ b/test/data/stats/favorites_stats_item_builder_test.dart
@@ -1,0 +1,189 @@
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/stats/item_builder/favorites_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../util/book_test_utils.dart';
+
+void main() {
+  final FavoritesStatsItemBuilder itemBuilder = FavoritesStatsItemBuilder();
+
+  test('Favorites stats with empty books', () {
+    final List<Book> data = [];
+
+    final FavoritesStatsItem item = itemBuilder.buildStatsItem(data);
+
+    expect(item.dataState, isA<EmptyFavoritesData>());
+  });
+
+  test('Favorites stats with single book, no 5 star rating', () {
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: DateTime.now()),
+      ],
+    );
+
+    final FavoritesStatsItem item = itemBuilder.buildStatsItem(data);
+
+    expect(
+      item.dataState,
+      equals(
+        FavoritesData(
+          favoriteAuthor: data,
+          firstFiveStarBook: null,
+        ),
+      ),
+    );
+  });
+
+  test('Favorites stats with single most read author, no 5 star rating', () {
+    final currentDateTime = DateTime.now();
+
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(
+          author: 'Marcus Aurelius',
+          date: currentDateTime,
+        ),
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+      ],
+    );
+
+    final FavoritesStatsItem item = itemBuilder.buildStatsItem(data);
+
+    final List<Book> favAuthorBooks = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+      ],
+    );
+
+    expect(
+      item.dataState,
+      equals(
+        FavoritesData(
+          favoriteAuthor: favAuthorBooks,
+          firstFiveStarBook: null,
+        ),
+      ),
+    );
+  });
+
+  test('Favorites stats with multiple most read authors, no 5 star rating', () {
+    final currentDateTime = DateTime.now();
+
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+        TestBookSeed.forAuthor(
+          author: 'Marcus Aurelius',
+          date: currentDateTime,
+        ),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Ryan Holiday', date: currentDateTime),
+      ],
+    );
+
+    final FavoritesStatsItem item = itemBuilder.buildStatsItem(data);
+
+    final List<Book> favAuthorBooks = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+        TestBookSeed.forAuthor(author: 'Robert Greene', date: currentDateTime),
+      ],
+    );
+
+    expect(
+      item.dataState,
+      equals(
+        FavoritesData(
+          favoriteAuthor: favAuthorBooks,
+          firstFiveStarBook: null,
+        ),
+      ),
+    );
+  });
+
+  test('Favorites stats with single most read author, a 5 star rating', () {
+    final currentDateTime = DateTime.now();
+
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Robert Greene',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Marcus Aurelius',
+          date: DateTime(2022, 5),
+          rating: 5,
+        ),
+      ],
+    );
+
+    final FavoritesStatsItem item = itemBuilder.buildStatsItem(data);
+
+    final Book firstFiveStarBook = BookTestUtils.generateFromSeed(
+      TestBookSeed.forAuthor(
+        author: 'Marcus Aurelius',
+        date: DateTime(2022, 5),
+        rating: 5,
+      ),
+      index: 4,
+    );
+
+    final List<Book> favAuthorBooks = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+        TestBookSeed.forAuthor(
+          author: 'Ryan Holiday',
+          date: currentDateTime,
+          rating: 5,
+        ),
+      ],
+    );
+
+    expect(
+      item.dataState,
+      equals(
+        FavoritesData(
+          favoriteAuthor: favAuthorBooks,
+          firstFiveStarBook: firstFiveStarBook,
+        ),
+      ),
+    );
+  });
+}

--- a/test/data/stats/misc_stats_item_builder_test.dart
+++ b/test/data/stats/misc_stats_item_builder_test.dart
@@ -1,0 +1,140 @@
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
+import 'package:dantex/src/data/stats/item_builder/misc_stats_item_builder.dart';
+import 'package:dantex/src/data/stats/stats_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../util/book_test_utils.dart';
+
+
+void main() {
+  final DateTime currentDateTime = DateTime(2023, 10);
+  final MiscStatsItemBuilder itemBuilder = MiscStatsItemBuilder(
+    currentDateTime,
+  );
+
+  test('Misc stats with empty books', () {
+    final List<Book> data = [];
+
+    final MiscStatsItem item = itemBuilder.buildStatsItem(data);
+
+    expect(item.dataState, isA<EmptyMiscData>());
+  });
+
+  test('Misc stats with no book finished', () {
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed(
+          state: BookState.reading,
+          startDate: DateTime.now(),
+          forLaterDate: DateTime.now(),
+        ),
+      ],
+    );
+
+    final MiscStatsItem item = itemBuilder.buildStatsItem(data);
+
+    expect(
+      item.dataState,
+      equals(
+        const MiscData(
+          averageBooksPerMonth: 0,
+          mostActiveMonth: null,
+        ),
+      ),
+    );
+  });
+
+  test('Misc stats with single book finished', () {
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+      ],
+    );
+
+    final MiscStatsItem item = itemBuilder.buildStatsItem(data);
+
+    expect(
+      item.dataState,
+      equals(
+        MiscData(
+          averageBooksPerMonth: 1,
+          mostActiveMonth: MostActiveMonth(
+            month: DateTime(2023, 10),
+            books: data,
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('Misc stats with many books finished', () {
+    final List<Book> data = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 9, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 8, 10),
+        ),
+      ],
+    );
+
+    final MiscStatsItem item = itemBuilder.buildStatsItem(data);
+
+    final expectedBookData = BookTestUtils.generateBooksWithSeed(
+      [
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+        TestBookSeed.singleDate(
+          state: BookState.read,
+          date: DateTime(2023, 10, 10),
+        ),
+      ],
+    );
+
+    expect(
+      item.dataState,
+      equals(
+        MiscData(
+          averageBooksPerMonth: 2.0,
+          mostActiveMonth: MostActiveMonth(
+            month: DateTime(2023, 10),
+            books: expectedBookData,
+          ),
+        ),
+      ),
+    );
+  });
+}

--- a/test/util/book_test_utils.dart
+++ b/test/util/book_test_utils.dart
@@ -1,0 +1,81 @@
+import 'package:collection/collection.dart';
+import 'package:dantex/src/data/book/entity/book.dart';
+import 'package:dantex/src/data/book/entity/book_state.dart';
+
+class BookTestUtils {
+  BookTestUtils._();
+
+  static Book generateFromSeed(
+    TestBookSeed seed, {
+    int index = 0,
+  }) {
+    return _fromSeedAndIndex(seed, index);
+  }
+
+  static List<Book> generateBooksWithSeed(List<TestBookSeed> seeds) {
+    return seeds
+        .mapIndexed(
+          (index, element) => _fromSeedAndIndex(element, index),
+        )
+        .toList();
+  }
+
+  static Book _fromSeedAndIndex(TestBookSeed seed, int index) {
+    return Book(
+      id: index.toString(),
+      title: index.toString(),
+      subTitle: index.toString(),
+      author: seed.author ?? index.toString(),
+      state: seed.state,
+      pageCount: 256,
+      currentPage: 0,
+      publishedDate: '',
+      position: 0,
+      isbn: '12345678',
+      thumbnailAddress: null,
+      startDate: seed.startDate,
+      endDate: seed.endDate,
+      forLaterDate: seed.forLaterDate,
+      language: 'en',
+      rating: seed.rating,
+      notes: index.toString(),
+      summary: index.toString(),
+    );
+  }
+}
+
+class TestBookSeed {
+  final BookState state;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final DateTime? forLaterDate;
+  final int rating;
+  final String? author;
+
+  TestBookSeed({
+    required this.state,
+    this.startDate,
+    this.endDate,
+    this.forLaterDate,
+    this.rating = 0,
+    this.author,
+  });
+
+  TestBookSeed.singleDate({
+    required this.state,
+    required DateTime date,
+    this.rating = 0,
+    this.author,
+  })  : startDate = date,
+        endDate = date,
+        forLaterDate = date;
+
+  TestBookSeed.forAuthor({
+    required this.author,
+    required DateTime date,
+    this.rating = 0,
+  })  : startDate = date,
+        endDate = date,
+        forLaterDate = date,
+        state = BookState.read;
+}


### PR DESCRIPTION
### Description

Implement the stats screen, with a couple of exceptions. Right now, there are no `Pages per month`, and no way to set a goal for monthly read pages, or books. This will come in a separate PR.

### Screenshots
<img width="1792" alt="Bildschirmfoto 2024-01-07 um 11 21 20" src="https://github.com/shockbytes/DanteX/assets/12248553/835e3c03-e07e-4461-adde-1ffee7733791">
